### PR TITLE
fix: banner de devolución muestra el saldo disponible en rendición di…

### DIFF
--- a/src/app/modules/mis-rendiciones/rendicion-detail/rendicion-detail.component.ts
+++ b/src/app/modules/mis-rendiciones/rendicion-detail/rendicion-detail.component.ts
@@ -124,6 +124,11 @@ export class RendicionDetailComponent implements OnInit {
   }
 
   get saldoLibre(): number {
+    // Rendición directa con depósito de Contabilidad: el saldo a devolver es el
+    // depósito menos lo gastado (en vivo), no el monto del settlement almacenado.
+    if (this.hasDirectaDeposit) {
+      return this.directaSaldo;
+    }
     if (this.settlement?.difference !== undefined && this.settlement.difference !== null) {
       return this.settlement.difference;
     }


### PR DESCRIPTION
…recta

saldoLibre devuelve depósito - gastado (en vivo) cuando hay depósito de Contabilidad, en vez del settlement almacenado, para que el banner del colaborador muestre el saldo correcto.