### PR TITLE
feat: pagos parciales de viáticos — escaneo, alerta y presupuesto acu…

### DIFF
--- a/src/app/interfaces/advance.interface.ts
+++ b/src/app/interfaces/advance.interface.ts
@@ -3,6 +3,7 @@ export type AdvanceStatus =
   | 'pending_l1'
   | 'pending_l2'
   | 'approved'
+  | 'partially_paid'
   | 'paid'
   | 'settled'
   | 'rejected'
@@ -28,6 +29,27 @@ export interface IPaymentInfo {
   paymentReceiptFileName?: string;
   paymentReceiptMimeType?: string;
   paymentReceiptSizeBytes?: number;
+}
+
+/** Pago parcial de un viático (contabilidad puede registrar varios). */
+export interface IAdvancePayment {
+  amount: number;
+  method: 'transferencia_bancaria' | 'efectivo' | 'cheque';
+  bankName?: string;
+  accountNumber?: string;
+  cci?: string;
+  transferDate: string;
+  reference?: string;
+  paymentReceiptUrl: string;
+  paymentReceiptFileName?: string;
+  paymentReceiptMimeType?: string;
+  paymentReceiptSizeBytes?: number;
+  scannedAmount?: number;
+  scannedTitular?: string;
+  operationNumber?: string;
+  operationDate?: string;
+  operationTime?: string;
+  createdAt?: string;
 }
 
 export interface IAdvanceSettlement {
@@ -109,6 +131,8 @@ export interface IAdvance {
   requiredLevels: number;
   approvalHistory: IApprovalEntry[];
   paymentInfo?: IPaymentInfo;
+  payments?: IAdvancePayment[];
+  paidAmount?: number;
   settlement?: IAdvanceSettlement;
   rejectedBy?: string;
   rejectionReason?: string;
@@ -178,6 +202,7 @@ export interface IRejectAdvancePayload {
 }
 
 export interface IPayAdvancePayload {
+  amount?: number;
   method: 'transferencia_bancaria' | 'efectivo' | 'cheque';
   bankName?: string;
   accountNumber?: string;
@@ -188,6 +213,11 @@ export interface IPayAdvancePayload {
   paymentReceiptFileName?: string;
   paymentReceiptMimeType?: string;
   paymentReceiptSizeBytes?: number;
+  scannedAmount?: number;
+  scannedTitular?: string;
+  operationNumber?: string;
+  operationDate?: string;
+  operationTime?: string;
 }
 
 export const ADVANCE_STATUS_LABELS: Record<AdvanceStatus, string> = {
@@ -195,6 +225,7 @@ export const ADVANCE_STATUS_LABELS: Record<AdvanceStatus, string> = {
   pending_l1: 'Pendiente Aprobación',
   pending_l2: 'Aprobado por Coordinador',
   approved: 'Aprobado',
+  partially_paid: 'Pago parcial',
   paid: 'Pagado',
   settled: 'Liquidado',
   rejected: 'Rechazado',
@@ -207,6 +238,7 @@ export const ADVANCE_STATUS_COLORS: Record<AdvanceStatus, string> = {
   pending_l1: 'bg-yellow-100 text-yellow-700',
   pending_l2: 'bg-orange-100 text-orange-700',
   approved: 'bg-blue-100 text-blue-700',
+  partially_paid: 'bg-cyan-100 text-cyan-700',
   paid: 'bg-green-100 text-green-700',
   settled: 'bg-emerald-100 text-emerald-700',
   rejected: 'bg-red-100 text-red-700',

--- a/src/app/modules/inicio/inicio.component.ts
+++ b/src/app/modules/inicio/inicio.component.ts
@@ -77,7 +77,7 @@ export class InicioComponent implements OnInit {
 
   paidAdvances = computed(() =>
     this.advances()
-      .filter((a) => a.status === 'paid')
+      .filter((a) => a.status === 'paid' || a.status === 'partially_paid')
       .filter((a) => {
         const reportId = this.getAdvanceReportId(a);
         if (!reportId) return true;
@@ -88,8 +88,8 @@ export class InicioComponent implements OnInit {
 
   kpiAnticiposMonto = computed(() =>
     this.advances()
-      .filter((a) => ['approved', 'paid', 'settled'].includes(a.status))
-      .reduce((sum, a) => sum + a.amount, 0)
+      .filter((a) => ['approved', 'partially_paid', 'paid', 'settled'].includes(a.status))
+      .reduce((sum, a) => sum + (a.status === 'approved' ? 0 : Number(a.paidAmount ?? a.amount) || 0), 0)
   );
 
   // ── Recientes ────────────────────────────────────────────────────

--- a/src/app/modules/invoices/add-invoice/add-invoice.component.ts
+++ b/src/app/modules/invoices/add-invoice/add-invoice.component.ts
@@ -503,9 +503,10 @@ export default class AddInvoiceComponent implements OnInit {
               ? (a.expenseReportId as any)?._id
               : a.expenseReportId;
             return rid === this.rendicionId
-              && ['approved', 'paid', 'settled'].includes(a.status);
+              && ['approved', 'partially_paid', 'paid', 'settled'].includes(a.status);
           })
-          .reduce((sum, a) => sum + (Number(a.amount) || 0), 0);
+          // Presupuesto = lo realmente pagado (paidAmount); 'approved' sin pago aporta 0.
+          .reduce((sum, a) => sum + (a.status === 'approved' ? 0 : Number(a.paidAmount ?? a.amount) || 0), 0);
         this.rendicionBudget.set(totalAnticipado);
       },
       error: (err) => console.error('Error loading advances', err),

--- a/src/app/modules/mis-rendiciones/mis-rendiciones.component.html
+++ b/src/app/modules/mis-rendiciones/mis-rendiciones.component.html
@@ -81,10 +81,10 @@
       @for (adv of pendingAdvances; track adv._id) {
       <div
         class="rounded-xl border shadow-sm p-5 flex flex-col gap-3 transition-all"
-        [class]="adv.status === 'paid' && hasExpenseReportLink(adv)
+        [class]="isAdvancePaidOrPartial(adv) && hasExpenseReportLink(adv)
           ? 'bg-emerald-50 border-emerald-300 cursor-pointer hover:border-emerald-500 hover:shadow-md'
           : 'bg-white border-gray-200'"
-        (click)="adv.status === 'paid' && hasExpenseReportLink(adv) ? navigateToAdvanceReport(adv) : null"
+        (click)="isAdvancePaidOrPartial(adv) && hasExpenseReportLink(adv) ? navigateToAdvanceReport(adv) : null"
       >
         <div class="flex justify-between items-start gap-2">
           <span [class]="ADVANCE_STATUS_COLORS[adv.status]" class="inline-flex px-2.5 py-0.5 rounded-full text-xs font-semibold">
@@ -159,7 +159,7 @@
           Corregir y reenviar
         </button>
         }
-        @if (adv.status === 'paid' && hasExpenseReportLink(adv)) {
+        @if (isAdvancePaidOrPartial(adv) && hasExpenseReportLink(adv)) {
         <div class="flex items-center justify-between rounded-lg bg-emerald-100 border border-emerald-300 px-3 py-2 mt-auto">
           <span class="text-xs font-semibold text-emerald-800">Toca para registrar tus gastos</span>
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-4 h-4 text-emerald-700 shrink-0">

--- a/src/app/modules/mis-rendiciones/mis-rendiciones.component.ts
+++ b/src/app/modules/mis-rendiciones/mis-rendiciones.component.ts
@@ -400,12 +400,17 @@ export class MisRendicionesComponent implements OnInit {
   }
 
   advanceStatusText(adv: IAdvance): string {
-    if (adv.status === 'paid') return 'En Progreso - Registrando Gastos';
+    if (adv.status === 'paid' || adv.status === 'partially_paid') return 'En Progreso - Registrando Gastos';
     return this.ADVANCE_STATUS_LABELS[adv.status];
   }
 
   hasExpenseReportLink(adv: IAdvance): boolean {
     return !!this.getExpenseReportId(adv);
+  }
+
+  /** El viático ya tiene pago (parcial o total) → el colaborador puede registrar gastos. */
+  isAdvancePaidOrPartial(adv: IAdvance): boolean {
+    return adv.status === 'paid' || adv.status === 'partially_paid';
   }
 
   get pendingAdvances(): IAdvance[] {
@@ -520,7 +525,7 @@ export class MisRendicionesComponent implements OnInit {
         adv.expenseReportId && typeof adv.expenseReportId === 'object'
           ? adv.expenseReportId._id
           : null;
-      return rid === report._id && (adv.status === 'paid' || adv.status === 'settled');
+      return rid === report._id && ['partially_paid', 'paid', 'settled'].includes(adv.status);
     });
   }
 

--- a/src/app/modules/mis-rendiciones/rendicion-detail/rendicion-detail.component.html
+++ b/src/app/modules/mis-rendiciones/rendicion-detail/rendicion-detail.component.html
@@ -518,11 +518,26 @@
           </div>
           <p class="text-2xl sm:text-3xl font-bold text-gray-900 tabular-nums">S/ {{ totalAnticipado | number:'1.2-2' }}</p>
           @if (paidAdvances.length > 0) {
-            <ul class="mt-3 space-y-1 border-t border-gray-100 pt-2">
+            <ul class="mt-3 space-y-2 border-t border-gray-100 pt-2">
               @for (adv of paidAdvances; track adv._id) {
-                <li class="flex items-center justify-between gap-2 text-xs">
-                  <span class="text-gray-500 truncate">{{ adv.place || adv.description }}</span>
-                  <span class="tabular-nums font-medium text-gray-700 shrink-0">S/ {{ adv.amount | number:'1.2-2' }}</span>
+                <li class="text-xs">
+                  <div class="flex items-center justify-between gap-2">
+                    <span class="text-gray-500 truncate">{{ adv.place || adv.description }}</span>
+                    <span class="tabular-nums font-medium text-gray-700 shrink-0">S/ {{ advancePaidAmount(adv) | number:'1.2-2' }}</span>
+                  </div>
+                  @if (advancePayments(adv).length > 1) {
+                    <ul class="mt-1 ml-2 pl-2 border-l border-gray-100 space-y-0.5">
+                      @for (p of advancePayments(adv); track $index) {
+                        <li class="flex items-center justify-between gap-2 text-[11px] text-gray-400">
+                          <span>Pago {{ $index + 1 }}@if (p.transferDate) { · {{ p.transferDate | date:'dd/MM/yyyy' }} }</span>
+                          <span class="tabular-nums shrink-0">S/ {{ p.amount | number:'1.2-2' }}</span>
+                        </li>
+                      }
+                    </ul>
+                  }
+                  @if (advancePaidAmount(adv) < adv.amount) {
+                    <p class="mt-0.5 text-[11px] text-amber-600">Pago parcial · falta S/ {{ (adv.amount - advancePaidAmount(adv)) | number:'1.2-2' }}</p>
+                  }
                 </li>
               }
             </ul>

--- a/src/app/modules/mis-rendiciones/rendicion-detail/rendicion-detail.component.ts
+++ b/src/app/modules/mis-rendiciones/rendicion-detail/rendicion-detail.component.ts
@@ -11,7 +11,7 @@ import { ConfirmationService } from '../../../services/confirmation.service';
 import { InvoicesService } from '../../invoices/services/invoices.service';
 import { UploadService } from '../../../services/upload.service';
 import { IExpenseReport } from '../../../interfaces/expense-report.interface';
-import { IAdvance, ADVANCE_STATUS_LABELS, ADVANCE_STATUS_COLORS } from '../../../interfaces/advance.interface';
+import { IAdvance, IAdvancePayment, ADVANCE_STATUS_LABELS, ADVANCE_STATUS_COLORS } from '../../../interfaces/advance.interface';
 import { ButtonComponent } from '../../../design-system/button/button.component';
 import {
   CashVoucherExportData,
@@ -179,20 +179,31 @@ export class RendicionDetailComponent implements OnInit {
   }
 
   get totalAnticipado(): number {
+    // El presupuesto refleja lo realmente pagado (paidAmount) — soporta pagos parciales.
     const advances = this.advances
-      .filter(a => ['approved', 'paid', 'settled'].includes(a.status))
-      .reduce((sum, a) => sum + a.amount, 0);
+      .filter(a => ['approved', 'partially_paid', 'paid', 'settled'].includes(a.status))
+      .reduce((sum, a) => sum + Number(a.paidAmount ?? a.amount), 0);
     // El depósito de una rendición directa iniciada por Contabilidad funciona como
     // anticipo: el saldo no gastado debe devolverlo el colaborador/coordinador.
     return advances + (this.hasDirectaDeposit ? this.directaDeposited : 0);
   }
 
   get paidAdvances(): IAdvance[] {
-    return this.advances.filter(a => ['approved', 'paid', 'settled'].includes(a.status));
+    return this.advances.filter(a => ['approved', 'partially_paid', 'paid', 'settled'].includes(a.status));
   }
 
   get hasPaidAdvanceForReport(): boolean {
-    return this.advances.some(a => ['paid', 'settled'].includes(a.status));
+    // Con el primer pago (parcial o total) el colaborador ya puede rendir.
+    return this.advances.some(a => ['partially_paid', 'paid', 'settled'].includes(a.status));
+  }
+
+  /** Pagos parciales de un anticipo (para el desglose del presupuesto). */
+  advancePayments(adv: IAdvance): IAdvancePayment[] {
+    return Array.isArray(adv?.payments) ? adv.payments : [];
+  }
+
+  advancePaidAmount(adv: IAdvance): number {
+    return Number(adv?.paidAmount ?? adv?.amount ?? 0);
   }
 
   get settlement(): any {

--- a/src/app/modules/tesoreria/tesoreria.component.html
+++ b/src/app/modules/tesoreria/tesoreria.component.html
@@ -356,10 +356,10 @@
                   Rechazar
                 </button>
                 }
-                @if(adv.status === 'approved' && canPayAndSettle) {
+                @if(canRegisterPayment(adv)) {
                 <button type="button" (click)="openPaymentModal(adv)" [disabled]="isActing()"
                   class="text-xs px-3 py-1.5 bg-primary text-white rounded-lg hover:bg-primary/90 disabled:opacity-50 transition-colors font-medium">
-                  Registrar pago
+                  {{ payButtonLabel(adv) }}
                 </button>
                 }
                 @if(adv.status === 'settled' && adv.settlement?.type === 'devolucion' && canPayAndSettle) {
@@ -417,10 +417,10 @@
             Rechazar
           </button>
           }
-          @if(adv.status === 'approved' && canPayAndSettle) {
+          @if(canRegisterPayment(adv)) {
           <button type="button" (click)="openPaymentModal(adv)" [disabled]="isActing()"
             class="text-xs px-3 py-1.5 bg-primary text-white rounded-lg hover:bg-primary/90 disabled:opacity-50 transition-colors font-medium">
-            Registrar pago
+            {{ payButtonLabel(adv) }}
           </button>
           }
           @if(adv.status === 'settled' && adv.settlement?.type === 'devolucion' && canPayAndSettle) {
@@ -450,12 +450,66 @@
       <div class="flex items-start justify-between mb-0.5">
         <h3 class="text-lg font-bold text-secondary">Registrar comprobante de pago</h3>
       </div>
-      <p class="text-sm text-tertiary mb-5">
+      <p class="text-sm text-tertiary mb-2">
         <span class="font-semibold text-secondary">{{ getUserName(selectedAdvance) }}</span>
-        &nbsp;·&nbsp;S/ {{ selectedAdvance.amount | number:'1.2-2' }}
+        &nbsp;·&nbsp;Solicitado S/ {{ selectedAdvance.amount | number:'1.2-2' }}
       </p>
+      @if (advancePaid(selectedAdvance) > 0) {
+      <div class="mb-4 rounded-xl bg-background/70 border border-tertiary/20 px-3 py-2 text-xs text-tertiary flex items-center justify-between">
+        <span>Pagado: <span class="font-semibold text-secondary">S/ {{ advancePaid(selectedAdvance) | number:'1.2-2' }}</span></span>
+        <span>Falta: <span class="font-semibold" [class.text-error]="advanceRemaining(selectedAdvance) > 0">S/ {{ advanceRemaining(selectedAdvance) | number:'1.2-2' }}</span></span>
+      </div>
+      }
 
       <form [formGroup]="paymentForm" class="space-y-4">
+        <!-- Comprobante (se escanea al subir) -->
+        <div class="flex flex-col gap-1.5">
+          <label class="text-xs font-semibold text-tertiary uppercase tracking-wider">
+            Comprobante de pago <span class="text-error">*</span>
+          </label>
+          @if (!paymentReceiptName) {
+          <label class="flex flex-col items-center justify-center gap-2 h-24 rounded-xl border-2 border-dashed border-tertiary/30 hover:border-primary/40 hover:bg-primary/5 cursor-pointer transition-colors">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-tertiary">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5" />
+            </svg>
+            <span class="text-xs text-tertiary">PDF, JPG o PNG (máx. 10MB)</span>
+            <input type="file" accept=".pdf,.jpg,.jpeg,.png,application/pdf,image/jpeg,image/png"
+              (change)="onPaymentReceiptSelected($event)" class="hidden" />
+          </label>
+          } @else {
+          <div class="flex items-center gap-3 p-3 rounded-xl bg-green-50 border border-green-200">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-green-600 shrink-0">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+            </svg>
+            <span class="text-xs text-green-700 font-medium truncate flex-1">{{ paymentReceiptName }}</span>
+            <button type="button" (click)="removePaymentReceipt()"
+              class="text-xs text-tertiary hover:text-error transition-colors shrink-0">Quitar</button>
+          </div>
+          }
+          @if (isUploadingReceipt()) {
+          <p class="text-xs text-primary flex items-center gap-1.5">
+            <span class="inline-block w-3 h-3 border-2 border-primary border-t-transparent rounded-full animate-spin"></span>
+            Subiendo comprobante...
+          </p>
+          }
+          @if (isScanningPayment()) {
+          <p class="text-xs text-primary flex items-center gap-1.5">
+            <span class="inline-block w-3 h-3 border-2 border-primary border-t-transparent rounded-full animate-spin"></span>
+            Escaneando comprobante...
+          </p>
+          }
+        </div>
+
+        <!-- Monto de este pago (autocompletado del escaneo, editable) -->
+        <div class="flex flex-col gap-1.5">
+          <label class="text-xs font-semibold text-tertiary uppercase tracking-wider">Monto de este pago S/ <span class="text-error">*</span></label>
+          <input type="number" formControlName="amount" min="0" step="0.01" placeholder="0.00"
+            class="w-full h-[42px] px-3 rounded-xl border border-tertiary/30 text-sm text-secondary bg-quaternary focus:outline-none focus:ring-2 focus:ring-primary/30" />
+          @if (paymentScannedAmount !== null) {
+          <p class="text-[11px] text-tertiary">Monto detectado: S/ {{ paymentScannedAmount | number:'1.2-2' }}@if (paymentScannedTitular) { · {{ paymentScannedTitular }} }. Puedes editarlo.</p>
+          }
+        </div>
+
         <div class="flex flex-col gap-1.5">
           <label class="text-xs font-semibold text-tertiary uppercase tracking-wider">Método de pago</label>
           <select formControlName="method"
@@ -497,36 +551,24 @@
           </div>
         </div>
 
-        <div class="flex flex-col gap-1.5">
-          <label class="text-xs font-semibold text-tertiary uppercase tracking-wider">
-            Comprobante de pago <span class="text-error">*</span>
-          </label>
-          @if (!paymentReceiptName) {
-          <label class="flex flex-col items-center justify-center gap-2 h-24 rounded-xl border-2 border-dashed border-tertiary/30 hover:border-primary/40 hover:bg-primary/5 cursor-pointer transition-colors">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-tertiary">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5" />
-            </svg>
-            <span class="text-xs text-tertiary">PDF, JPG o PNG (máx. 10MB)</span>
-            <input type="file" accept=".pdf,.jpg,.jpeg,.png,application/pdf,image/jpeg,image/png"
-              (change)="onPaymentReceiptSelected($event)" class="hidden" />
-          </label>
-          } @else {
-          <div class="flex items-center gap-3 p-3 rounded-xl bg-green-50 border border-green-200">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-green-600 shrink-0">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
-            </svg>
-            <span class="text-xs text-green-700 font-medium truncate flex-1">{{ paymentReceiptName }}</span>
-            <button type="button" (click)="paymentReceiptUrl=null; paymentReceiptName=null"
-              class="text-xs text-tertiary hover:text-error transition-colors shrink-0">Quitar</button>
-          </div>
+        <!-- Datos detectados del comprobante -->
+        @if (paymentOperationNumber || paymentOperationDate || paymentOperationTime || paymentScannedTitular) {
+        <div class="rounded-xl border border-tertiary/20 bg-background/60 p-3 space-y-1.5">
+          <p class="text-[11px] font-semibold text-tertiary uppercase tracking-wider">Datos detectados del comprobante</p>
+          @if (paymentScannedTitular) {
+          <div class="flex justify-between gap-3 text-xs"><span class="text-tertiary">Titular</span><span class="font-medium text-secondary text-right">{{ paymentScannedTitular }}</span></div>
           }
-          @if (isUploadingReceipt()) {
-          <p class="text-xs text-primary flex items-center gap-1.5">
-            <span class="inline-block w-3 h-3 border-2 border-primary border-t-transparent rounded-full animate-spin"></span>
-            Subiendo comprobante...
-          </p>
+          @if (paymentOperationNumber) {
+          <div class="flex justify-between gap-3 text-xs"><span class="text-tertiary">N° operación</span><span class="font-medium text-secondary text-right">{{ paymentOperationNumber }}</span></div>
+          }
+          @if (paymentOperationDate) {
+          <div class="flex justify-between gap-3 text-xs"><span class="text-tertiary">Fecha</span><span class="font-medium text-secondary text-right">{{ paymentOperationDate }}</span></div>
+          }
+          @if (paymentOperationTime) {
+          <div class="flex justify-between gap-3 text-xs"><span class="text-tertiary">Hora</span><span class="font-medium text-secondary text-right">{{ paymentOperationTime }}</span></div>
           }
         </div>
+        }
       </form>
 
       <div class="flex gap-3 mt-6">
@@ -535,11 +577,53 @@
           Cancelar
         </button>
         <button type="button" (click)="confirmPayment()"
-          [disabled]="paymentForm.invalid || isActing() || isUploadingReceipt() || !paymentReceiptUrl"
+          [disabled]="paymentForm.invalid || isActing() || isUploadingReceipt() || isScanningPayment() || !paymentReceiptUrl"
           class="flex-1 h-[42px] bg-primary text-white rounded-xl text-sm font-medium hover:bg-primary/90 disabled:opacity-50 transition-colors">
-          {{ isActing() ? 'Registrando...' : 'Enviar aprobación de viáticos' }}
+          {{ isActing() ? 'Registrando...' : 'Registrar pago' }}
         </button>
       </div>
+    </div>
+  </div>
+</div>
+}
+
+<!-- Popup: alerta de diferencia (titular/monto) — no bloquea -->
+@if (showPaymentAlert() && paymentAlert(); as al) {
+<div class="fixed inset-0 z-[60] flex items-center justify-center p-4" (click)="dismissPaymentAlert()">
+  <div class="absolute inset-0 bg-black/40 backdrop-blur-sm"></div>
+  <div class="relative bg-white rounded-2xl shadow-xl w-full max-w-sm overflow-hidden" (click)="$event.stopPropagation()">
+    <div class="px-6 pt-6 pb-4">
+      <div class="flex items-center gap-3 mb-3">
+        <div class="p-2 bg-amber-50 rounded-xl">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-amber-600">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />
+          </svg>
+        </div>
+        <h3 class="text-base font-bold text-gray-900">Diferencia detectada en el comprobante</h3>
+      </div>
+      <p class="text-sm text-gray-500 mb-3">El comprobante no coincide con la solicitud. Puedes continuar de todos modos.</p>
+      <div class="space-y-2 text-sm">
+        @if (al.titularMismatch) {
+        <div class="rounded-lg bg-amber-50 border border-amber-200 p-2.5">
+          <p class="text-xs text-gray-500">Titular</p>
+          <p class="text-gray-800">Comprobante: <span class="font-semibold">{{ al.scannedTitular }}</span></p>
+          <p class="text-gray-800">Colaborador: <span class="font-semibold">{{ al.expectedName }}</span></p>
+        </div>
+        }
+        @if (al.amountMismatch) {
+        <div class="rounded-lg bg-amber-50 border border-amber-200 p-2.5">
+          <p class="text-xs text-gray-500">Monto</p>
+          <p class="text-gray-800">Comprobante: <span class="font-semibold">S/ {{ al.scannedAmount | number:'1.2-2' }}</span></p>
+          <p class="text-gray-800">Solicitado: <span class="font-semibold">S/ {{ al.expectedAmount | number:'1.2-2' }}</span></p>
+        </div>
+        }
+      </div>
+    </div>
+    <div class="px-6 pb-6 pt-1">
+      <button type="button" (click)="dismissPaymentAlert()"
+        class="w-full h-[42px] bg-primary text-white rounded-xl text-sm font-medium hover:bg-primary/90 transition-colors">
+        Entendido, continuar
+      </button>
     </div>
   </div>
 </div>

--- a/src/app/modules/tesoreria/tesoreria.component.ts
+++ b/src/app/modules/tesoreria/tesoreria.component.ts
@@ -69,6 +69,23 @@ export class TesoreriaComponent implements OnInit {
   paymentReceiptMimeType: string | null = null;
   paymentReceiptSizeBytes: number | null = null;
 
+  // Pago de viático: escaneo del comprobante (OCR), alerta y pago parcial
+  isScanningPayment = signal(false);
+  paymentScannedAmount: number | null = null;
+  paymentScannedTitular: string | null = null;
+  paymentOperationNumber: string | null = null;
+  paymentOperationDate: string | null = null;
+  paymentOperationTime: string | null = null;
+  showPaymentAlert = signal(false);
+  paymentAlert = signal<{
+    titularMismatch: boolean;
+    amountMismatch: boolean;
+    scannedTitular: string;
+    scannedAmount: number;
+    expectedName: string;
+    expectedAmount: number;
+  } | null>(null);
+
   paymentForm!: FormGroup;
   rejectForm!: FormGroup;
   returnForm!: FormGroup;
@@ -105,6 +122,7 @@ export class TesoreriaComponent implements OnInit {
       note: [''],
     });
     this.paymentForm = this.fb.group({
+      amount: [null, [Validators.required, Validators.min(0.01)]],
       method: ['transferencia_bancaria', Validators.required],
       bankName: [''],
       accountNumber: [''],
@@ -133,7 +151,7 @@ export class TesoreriaComponent implements OnInit {
       next: (advances) => {
         this.allAdvances = advances;
         this.pendingAdvances = advances.filter(a =>
-          ['pending_l2', 'approved'].includes(a.status)
+          ['pending_l2', 'approved', 'partially_paid'].includes(a.status)
         );
         this.isLoading.set(false);
         this.loadPendingReimbursements();
@@ -180,9 +198,9 @@ export class TesoreriaComponent implements OnInit {
   get filteredAdvances(): IAdvance[] {
     switch (this.activeTab()) {
       case 'pendientes':
-        return this.allAdvances.filter(a => ['pending_l2', 'approved'].includes(a.status));
+        return this.allAdvances.filter(a => ['pending_l2', 'approved', 'partially_paid'].includes(a.status));
       case 'aprobados':
-        return this.allAdvances.filter(a => ['approved', 'paid'].includes(a.status));
+        return this.allAdvances.filter(a => ['approved', 'partially_paid', 'paid'].includes(a.status));
       default:
         return this.allAdvances;
     }
@@ -229,6 +247,7 @@ export class TesoreriaComponent implements OnInit {
   openPaymentModal(advance: IAdvance) {
     this.selectedAdvance = advance;
     this.paymentForm.reset({
+      amount: this.advanceRemaining(advance) > 0 ? this.advanceRemaining(advance) : null,
       method: 'transferencia_bancaria',
       bankName: '',
       accountNumber: '',
@@ -240,6 +259,7 @@ export class TesoreriaComponent implements OnInit {
     this.paymentReceiptName = null;
     this.paymentReceiptMimeType = null;
     this.paymentReceiptSizeBytes = null;
+    this.resetPaymentScanState();
     const user = typeof advance.userId === 'object' ? advance.userId : null;
     if (user?.bankAccount) {
       this.paymentForm.patchValue({
@@ -249,6 +269,113 @@ export class TesoreriaComponent implements OnInit {
       });
     }
     this.showPaymentModal = true;
+  }
+
+  // ─── Pago de viático: acumulado y pagos parciales ────────────────────────────
+
+  advancePaid(advance: IAdvance): number {
+    return Number(advance?.paidAmount ?? 0);
+  }
+
+  advanceRemaining(advance: IAdvance): number {
+    return Math.max(Number(advance?.amount ?? 0) - this.advancePaid(advance), 0);
+  }
+
+  /** Contabilidad puede registrar/seguir registrando pagos mientras no se haya liquidado. */
+  canRegisterPayment(advance: IAdvance): boolean {
+    return (
+      this.canPayAndSettle &&
+      ['approved', 'partially_paid', 'paid'].includes(advance.status)
+    );
+  }
+
+  payButtonLabel(advance: IAdvance): string {
+    if (advance.status === 'partially_paid') return 'Registrar pago';
+    if (advance.status === 'paid') return 'Pago adicional';
+    return 'Registrar pago';
+  }
+
+  private resetPaymentScanState(): void {
+    this.paymentScannedAmount = null;
+    this.paymentScannedTitular = null;
+    this.paymentOperationNumber = null;
+    this.paymentOperationDate = null;
+    this.paymentOperationTime = null;
+    this.showPaymentAlert.set(false);
+    this.paymentAlert.set(null);
+  }
+
+  private scanPaymentReceipt(url: string, mimeType?: string): void {
+    this.isScanningPayment.set(true);
+    this.expenseReportsService.scanDepositAmount(url, mimeType).subscribe({
+      next: res => {
+        this.isScanningPayment.set(false);
+        const amount = Number(res?.amount) || 0;
+        this.paymentScannedAmount = amount;
+        this.paymentScannedTitular = res?.titular || null;
+        this.paymentOperationNumber = res?.operationNumber || null;
+        this.paymentOperationDate = res?.fecha || null;
+        this.paymentOperationTime = res?.hora || null;
+        const patch: Record<string, unknown> = {};
+        if (amount > 0) patch['amount'] = amount;
+        if (res?.operationNumber && !this.paymentForm.value.reference) patch['reference'] = res.operationNumber;
+        if (Object.keys(patch).length) this.paymentForm.patchValue(patch);
+        this.evaluatePaymentAlert();
+      },
+      error: () => {
+        this.isScanningPayment.set(false);
+        this.notificationService.show('No se pudo escanear el comprobante. Ingresa el monto manualmente.', 'warning');
+      },
+    });
+  }
+
+  /** Compara titular/monto escaneados contra el colaborador y el monto solicitado. Alerta no bloqueante. */
+  private evaluatePaymentAlert(): void {
+    const adv = this.selectedAdvance;
+    if (!adv) return;
+    const expectedName = this.getUserName(adv);
+    const expectedAmount = Number(adv.amount ?? 0);
+    const scannedTitular = this.paymentScannedTitular || '';
+    const scannedAmount = Number(this.paymentScannedAmount ?? 0);
+
+    const titularMismatch = !!scannedTitular && !this.namesRoughlyMatch(scannedTitular, expectedName);
+    const amountMismatch = scannedAmount > 0 && Math.abs(scannedAmount - expectedAmount) >= 0.01;
+
+    if (titularMismatch || amountMismatch) {
+      this.paymentAlert.set({ titularMismatch, amountMismatch, scannedTitular, scannedAmount, expectedName, expectedAmount });
+      this.showPaymentAlert.set(true);
+    }
+  }
+
+  /** Coincidencia laxa de nombres: ignora orden, mayúsculas y tildes; basta con que compartan tokens significativos. */
+  private namesRoughlyMatch(a: string, b: string): boolean {
+    const norm = (s: string) => s
+      .toLowerCase()
+      .normalize('NFD').replace(/[̀-ͯ]/g, '')
+      .replace(/[^a-z0-9\s]/g, ' ')
+      .split(/\s+/)
+      .filter(t => t.length > 2);
+    const ta = norm(a);
+    const tb = norm(b);
+    if (!ta.length || !tb.length) return false;
+    const setB = new Set(tb);
+    const shared = ta.filter(t => setB.has(t)).length;
+    // Coincide si comparten al menos 2 tokens, o todos los de la cadena más corta.
+    return shared >= 2 || shared === Math.min(ta.length, tb.length);
+  }
+
+  dismissPaymentAlert(): void {
+    this.showPaymentAlert.set(false);
+  }
+
+  /** Quita el comprobante y limpia los datos escaneados y el monto autocompletado. */
+  removePaymentReceipt(): void {
+    this.paymentReceiptUrl = null;
+    this.paymentReceiptName = null;
+    this.paymentReceiptMimeType = null;
+    this.paymentReceiptSizeBytes = null;
+    this.resetPaymentScanState();
+    this.paymentForm.patchValue({ amount: this.selectedAdvance && this.advanceRemaining(this.selectedAdvance) > 0 ? this.advanceRemaining(this.selectedAdvance) : null });
   }
 
   onPaymentReceiptSelected(event: Event) {
@@ -275,8 +402,9 @@ export class TesoreriaComponent implements OnInit {
         this.paymentReceiptName = file.name;
         this.paymentReceiptMimeType = file.type;
         this.paymentReceiptSizeBytes = file.size;
-        this.notificationService.show('Comprobante cargado correctamente', 'success');
         this.isUploadingReceipt.set(false);
+        // Escanea el comprobante: autocompleta el monto y verifica titular/monto.
+        this.scanPaymentReceipt(res.url, file.type);
       },
       error: () => {
         this.notificationService.show('No se pudo subir el comprobante', 'error');
@@ -401,10 +529,16 @@ export class TesoreriaComponent implements OnInit {
     this.isActing.set(true);
     this.advanceService.registerPayment(this.selectedAdvance._id, {
       ...this.paymentForm.value,
+      amount: Number(this.paymentForm.value.amount),
       paymentReceiptUrl: this.paymentReceiptUrl,
       paymentReceiptFileName: this.paymentReceiptName || undefined,
       paymentReceiptMimeType: this.paymentReceiptMimeType || undefined,
       paymentReceiptSizeBytes: this.paymentReceiptSizeBytes || undefined,
+      scannedAmount: this.paymentScannedAmount ?? undefined,
+      scannedTitular: this.paymentScannedTitular || undefined,
+      operationNumber: this.paymentOperationNumber || undefined,
+      operationDate: this.paymentOperationDate || undefined,
+      operationTime: this.paymentOperationTime || undefined,
     }).subscribe({
       next: () => {
         this.notificationService.show('Pago registrado correctamente', 'success');


### PR DESCRIPTION
…mulado

- Tesorería: modal de pago con escaneo del comprobante (imagen/PDF), monto autocompletado y editable, popup de alerta no bloqueante (titular/monto), acumulado "pagado X / falta Z" y pago adicional en partially_paid/paid
- Rendición: presupuesto = suma de lo pagado con desglose de pagos parciales (monto + fecha)
- gates de estado partially_paid (listas, inicio, add-invoice, "en progreso", rendir desde el primer pago)