### PR TITLE
feat(rendiciones-directas): dos pestañas (rendiciones/gastos) y colum…

### DIFF
--- a/src/app/modules/admin-users/rendiciones-admin/rendiciones-admin.component.ts
+++ b/src/app/modules/admin-users/rendiciones-admin/rendiciones-admin.component.ts
@@ -76,9 +76,13 @@ export class RendicionesAdminComponent implements OnInit {
 
     this.expenseReportsService.findAllByClient(clientId).subscribe({
       next: (reports) => {
-        this.allReports = reports.sort(
-          (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-        );
+        // Las rendiciones directas se gestionan en su propia sección
+        // (/rendiciones-directas). Aquí solo van las rendiciones con solicitud.
+        this.allReports = reports
+          .filter((r) => !r.isDirecta)
+          .sort(
+            (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+          );
         this.applyFilters();
         this.isLoading = false;
       },

--- a/src/app/modules/rendiciones-directas/rendiciones-directas.component.html
+++ b/src/app/modules/rendiciones-directas/rendiciones-directas.component.html
@@ -7,6 +7,7 @@
       <p class="text-sm text-gray-500 mt-0.5">Comprobantes de gastos directos para revision contable.</p>
     </div>
     <div class="flex items-center gap-2 flex-wrap">
+      @if (activeTab() === 'gastos') {
       @if (anySelected) {
         <span class="text-xs font-medium text-primary bg-primary/10 px-2.5 py-1.5 rounded-lg">
           {{ selectedCount }} seleccionado(s)
@@ -26,7 +27,26 @@
         </svg>
         @if (isExportingPdf()) { Generando... } @else if (anySelected) { PDF ({{ selectedCount }}) } @else { PDF }
       </button>
+      }
     </div>
+  </div>
+
+  <!-- Tabs -->
+  <div class="flex items-center gap-1 mb-4 border-b border-gray-200">
+    <button type="button" (click)="setTab('rendiciones')"
+      class="px-4 py-2.5 text-sm font-semibold border-b-2 -mb-px transition-colors"
+      [class.border-primary]="activeTab() === 'rendiciones'" [class.text-primary]="activeTab() === 'rendiciones'"
+      [class.border-transparent]="activeTab() !== 'rendiciones'" [class.text-gray-500]="activeTab() !== 'rendiciones'"
+      [class.hover:text-gray-700]="activeTab() !== 'rendiciones'">
+      Rendiciones directas
+    </button>
+    <button type="button" (click)="setTab('gastos')"
+      class="px-4 py-2.5 text-sm font-semibold border-b-2 -mb-px transition-colors"
+      [class.border-primary]="activeTab() === 'gastos'" [class.text-primary]="activeTab() === 'gastos'"
+      [class.border-transparent]="activeTab() !== 'gastos'" [class.text-gray-500]="activeTab() !== 'gastos'"
+      [class.hover:text-gray-700]="activeTab() !== 'gastos'">
+      Gastos
+    </button>
   </div>
 
   <!-- Filtros -->
@@ -47,6 +67,7 @@
           @for (u of users(); track u._id) { <option [value]="u._id">{{ u.name || u.email }}</option> }
         </select>
       </div>
+      @if (activeTab() === 'gastos') {
       <div>
         <label class="block text-xs font-medium text-gray-500 mb-1">Tipo</label>
         <select [(ngModel)]="filterTipo" class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 bg-white">
@@ -76,6 +97,7 @@
         <label class="block text-xs font-medium text-gray-500 mb-1">N° Comprobante</label>
         <input type="text" [(ngModel)]="filterDocNumber" placeholder="Serie, correlativo..." class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30" />
       </div>
+      }
     </div>
     <div class="flex justify-end gap-2 mt-3">
       <button type="button" (click)="clearFilters()" class="px-4 py-2 text-sm font-medium text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors">Limpiar</button>
@@ -85,6 +107,7 @@
 
   <!-- Tabla -->
   <div class="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden">
+    @if (activeTab() === 'gastos') {
     <div class="px-4 py-3 border-b border-gray-100 flex items-center justify-between gap-3">
       <p class="text-sm text-gray-500">
         @if (loading()) { Cargando... }
@@ -119,6 +142,7 @@
               <th class="px-3 py-3 whitespace-nowrap">Tipo</th>
               <th class="px-3 py-3 whitespace-nowrap">N° Doc</th>
               <th class="px-3 py-3 whitespace-nowrap">Colaborador</th>
+              <th class="px-3 py-3 whitespace-nowrap">Generado por</th>
               <th class="px-3 py-3 whitespace-nowrap">Proyecto</th>
               <th class="px-3 py-3 whitespace-nowrap">Categoria</th>
               <th class="px-3 py-3 whitespace-nowrap">Proveedor</th>
@@ -142,6 +166,12 @@
               </td>
               <td class="px-3 py-2.5 font-mono text-xs text-gray-700 whitespace-nowrap">{{ getDocNumber(e) }}</td>
               <td class="px-3 py-2.5 text-xs text-gray-700 whitespace-nowrap max-w-[120px]"><span class="block truncate" [title]="getColaborador(e)">{{ getColaborador(e) }}</span></td>
+              <td class="px-3 py-2.5 text-xs text-gray-700 max-w-[150px]">
+                <div class="flex flex-col gap-0.5">
+                  <span class="block truncate" [title]="getGeneradoPor(e)">{{ getGeneradoPor(e) }}</span>
+                  <span class="inline-flex items-center self-start px-1.5 py-0.5 rounded text-[10px] font-semibold" [ngClass]="getOrigenBadgeClass(e)">{{ getOrigenLabel(e) }}</span>
+                </div>
+              </td>
               <td class="px-3 py-2.5 text-xs text-gray-700 max-w-[130px]"><span class="block truncate" [title]="getProject(e)">{{ getProject(e) }}</span></td>
               <td class="px-3 py-2.5 text-xs text-gray-700 max-w-[110px]"><span class="block truncate" [title]="getCategory(e)">{{ getCategory(e) }}</span></td>
               <td class="px-3 py-2.5 text-xs text-gray-700 max-w-[150px]"><span class="block truncate" [title]="getProveedor(e)">{{ getProveedor(e) }}</span></td>
@@ -150,6 +180,9 @@
 
               <!-- Columna REVISADO CONT. — mismo estilo que rendicion-detail -->
               <td class="px-3 py-2.5 text-center">
+                @if (isDeposito(e)) {
+                  <span class="text-xs text-gray-400">—</span>
+                } @else {
                 <div class="flex flex-col items-center gap-1">
                   @if (isRevisado(e)) {
                     <!-- Aprobado: badge verde igual que rendicion-detail -->
@@ -177,6 +210,7 @@
                     <span class="text-[10px] text-yellow-600 font-medium">Pendiente</span>
                   }
                 </div>
+                }
               </td>
 
               <!-- Opciones — iconos igual que rendicion-detail (sin Editar) -->
@@ -241,6 +275,7 @@
                   </div>
                   }
                   <!-- Eliminar -->
+                  @if (!isDeposito(e)) {
                   <div class="relative group/del">
                     <button type="button" (click)="openDeleteConfirm(e, $event)"
                       class="inline-flex items-center justify-center w-8 h-8 rounded-lg text-gray-500 hover:bg-red-50 hover:text-red-600 transition-colors">
@@ -250,6 +285,7 @@
                     </button>
                     <div class="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 bg-gray-800 text-white text-[11px] rounded whitespace-nowrap opacity-0 group-hover/del:opacity-100 pointer-events-none transition-opacity z-10">Eliminar</div>
                   </div>
+                  }
                 </div>
               </td>
             </tr>
@@ -276,6 +312,78 @@
         <button type="button" (click)="goToPage(page + 1)" [disabled]="page === pages()" class="px-2 py-1.5 text-sm rounded-lg border border-gray-300 text-gray-600 hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors">&rsaquo;</button>
       </div>
       }
+    }
+    }
+    @else {
+    <!-- ───── Pestaña: Rendiciones directas (una fila por rendición) ───── -->
+    <div class="px-4 py-3 border-b border-gray-100">
+      <p class="text-sm text-gray-500">
+        @if (loadingReports()) { Cargando... }
+        @else { <span class="font-semibold text-gray-800">{{ reports().length }}</span> rendición(es) · Total gastado: <span class="font-semibold">S/ {{ reportsTotalGastado | number:'1.2-2' }}</span> }
+      </p>
+    </div>
+
+    @if (loadingReports()) {
+      <div class="flex items-center justify-center py-16"><span class="w-8 h-8 border-4 border-primary/20 border-t-primary rounded-full animate-spin"></span></div>
+    } @else if (reports().length === 0) {
+      <div class="flex flex-col items-center justify-center py-16 text-gray-400">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-12 h-12 mb-3 opacity-40"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" /></svg>
+        <p class="text-sm font-medium">Sin rendiciones directas. Ajusta los filtros.</p>
+      </div>
+    } @else {
+      <div class="overflow-x-auto">
+        <table class="w-full text-sm divide-y divide-gray-200">
+          <thead class="bg-gray-50 text-xs font-semibold text-gray-500 uppercase tracking-wider text-left">
+            <tr>
+              <th class="px-3 py-3 whitespace-nowrap">Código</th>
+              <th class="px-3 py-3 whitespace-nowrap">Fecha</th>
+              <th class="px-3 py-3 whitespace-nowrap">Colaborador</th>
+              <th class="px-3 py-3 whitespace-nowrap">Generado por</th>
+              <th class="px-3 py-3 whitespace-nowrap">Estado</th>
+              <th class="px-3 py-3 text-center whitespace-nowrap">N° Gastos</th>
+              <th class="px-3 py-3 text-right whitespace-nowrap">Depósito S/</th>
+              <th class="px-3 py-3 text-right whitespace-nowrap">Gastado S/</th>
+              <th class="px-3 py-3 text-right whitespace-nowrap">Saldo S/</th>
+              <th class="px-3 py-3 text-center whitespace-nowrap">Opciones</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-100 bg-white">
+            @for (r of reports(); track r._id) {
+            <tr class="hover:bg-gray-50 transition-colors cursor-pointer" (click)="viewReport(r)">
+              <td class="px-3 py-2.5 font-mono text-xs font-semibold text-gray-800 whitespace-nowrap">{{ r.codigo || '—' }}</td>
+              <td class="px-3 py-2.5 text-gray-700 whitespace-nowrap text-xs">{{ reportFecha(r) }}</td>
+              <td class="px-3 py-2.5 text-xs text-gray-700 max-w-[150px]"><span class="block truncate" [title]="reportColaborador(r)">{{ reportColaborador(r) }}</span></td>
+              <td class="px-3 py-2.5 text-xs text-gray-700 max-w-[160px]">
+                <div class="flex flex-col gap-0.5">
+                  <span class="block truncate" [title]="r.generatedByName || '—'">{{ r.generatedByName || '—' }}</span>
+                  <span class="inline-flex items-center self-start px-1.5 py-0.5 rounded text-[10px] font-semibold" [ngClass]="reportOrigenBadgeClass(r)">{{ reportOrigenLabel(r) }}</span>
+                </div>
+              </td>
+              <td class="px-3 py-2.5 text-xs"><span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">{{ reportStatusLabel(r) }}</span></td>
+              <td class="px-3 py-2.5 text-center text-xs text-gray-700 tabular-nums">{{ r.expenseCount }}</td>
+              <td class="px-3 py-2.5 text-right tabular-nums whitespace-nowrap text-gray-700">{{ r.hasDeposit ? ('S/ ' + (r.deposited | number:'1.2-2')) : '—' }}</td>
+              <td class="px-3 py-2.5 text-right font-semibold tabular-nums whitespace-nowrap text-gray-900">S/ {{ r.totalGastado | number:'1.2-2' }}</td>
+              <td class="px-3 py-2.5 text-right tabular-nums whitespace-nowrap" [ngClass]="(r.saldo ?? 0) < 0 ? 'text-red-600 font-semibold' : 'text-gray-700'">{{ r.saldo == null ? '—' : ('S/ ' + (r.saldo | number:'1.2-2')) }}</td>
+              <td class="px-3 py-2.5">
+                <div class="flex items-center justify-center">
+                  <div class="relative group/det">
+                    <button type="button" (click)="viewReport(r); $event.stopPropagation()"
+                      class="inline-flex items-center justify-center w-8 h-8 rounded-lg text-gray-500 hover:bg-gray-100 hover:text-gray-900 transition-colors">
+                      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z" />
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+                      </svg>
+                    </button>
+                    <div class="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 bg-gray-800 text-white text-[11px] rounded whitespace-nowrap opacity-0 group-hover/det:opacity-100 pointer-events-none transition-opacity z-10">Ver detalle</div>
+                  </div>
+                </div>
+              </td>
+            </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    }
     }
   </div>
 </div>

--- a/src/app/modules/rendiciones-directas/rendiciones-directas.component.ts
+++ b/src/app/modules/rendiciones-directas/rendiciones-directas.component.ts
@@ -37,11 +37,19 @@ export class RendicionesDirectasComponent implements OnInit {
   private router = inject(Router);
   private adminUsersService = inject(AdminUsersService);
 
-  // Estado
+  // Pestañas: "rendiciones" (una fila por rendición) y "gastos" (por comprobante).
+  activeTab = signal<'rendiciones' | 'gastos'>('rendiciones');
+  setTab(tab: 'rendiciones' | 'gastos'): void { this.activeTab.set(tab); }
+
+  // Estado — pestaña Gastos (por comprobante)
   loading = signal(false);
   data = signal<any[]>([]);
   total = signal(0);
   pages = signal(0);
+
+  // Estado — pestaña Rendiciones directas (por reporte)
+  reports = signal<any[]>([]);
+  loadingReports = signal(false);
 
   // Filtros
   filterDateFrom = '';
@@ -95,6 +103,7 @@ export class RendicionesDirectasComponent implements OnInit {
 
   ngOnInit(): void {
     this.loadCatalogs();
+    this.loadReports();
     this.loadData();
   }
 
@@ -128,13 +137,65 @@ export class RendicionesDirectasComponent implements OnInit {
     });
   }
 
-  applyFilters(): void { this.page = 1; this.loadData(); }
+  loadReports(): void {
+    const cid = this.clientId;
+    if (!cid) return;
+    this.loadingReports.set(true);
+    this.expenseReportsService.findDirectRendicionReports(cid, {
+      dateFrom: this.filterDateFrom || undefined,
+      dateTo: this.filterDateTo || undefined,
+      userId: this.filterUserId || undefined,
+    }).subscribe({
+      next: rows => { this.reports.set(rows ?? []); this.loadingReports.set(false); },
+      error: () => { this.loadingReports.set(false); this.notifications.show('Error al cargar las rendiciones', 'error'); },
+    });
+  }
+
+  applyFilters(): void { this.page = 1; this.loadReports(); this.loadData(); }
 
   clearFilters(): void {
     this.filterDateFrom = ''; this.filterDateTo = ''; this.filterProjectId = '';
     this.filterCategoryId = ''; this.filterDocNumber = ''; this.filterTipo = '';
     this.filterUserId = '';
-    this.page = 1; this.loadData();
+    this.page = 1; this.loadReports(); this.loadData();
+  }
+
+  // ─── Helpers pestaña Rendiciones directas (nivel reporte) ────────────────────
+
+  reportColaborador(r: any): string {
+    const u = r?.userId;
+    if (!u) return '—';
+    return (typeof u === 'object' ? u.name || u.email : u) || '—';
+  }
+
+  reportOrigenLabel(r: any): string {
+    const labels: Record<string, string> = { contabilidad: 'Contabilidad', coordinador: 'Coordinador', colaborador: 'Colaborador' };
+    return labels[r?.origin] ?? 'Colaborador';
+  }
+
+  reportOrigenBadgeClass(r: any): string {
+    if (r?.origin === 'contabilidad') return 'bg-blue-100 text-blue-700';
+    if (r?.origin === 'coordinador') return 'bg-purple-100 text-purple-700';
+    return 'bg-gray-100 text-gray-600';
+  }
+
+  reportStatusLabel(r: any): string {
+    const map: Record<string, string> = {
+      open: 'Abierta', solicited: 'Solicitada', submitted: 'Enviada',
+      pending_accounting: 'En contabilidad', approved: 'Aprobada',
+      rejected: 'Rechazada', closed: 'Cerrada', liquidated: 'Liquidada',
+    };
+    return map[String(r?.status || '')] ?? (r?.status || '—');
+  }
+
+  reportFecha(r: any): string { return formatFechaEmisionDdMmYyyy(r?.createdAt) || '—'; }
+
+  viewReport(r: any): void {
+    this.router.navigate(['/mis-rendiciones', String(r._id), 'detalle']);
+  }
+
+  get reportsTotalGastado(): number {
+    return this.reports().reduce((sum, r) => sum + (Number(r?.totalGastado) || 0), 0);
   }
 
   goToPage(p: number): void { if (p < 1 || p > this.pages()) return; this.page = p; this.loadData(); }
@@ -142,6 +203,12 @@ export class RendicionesDirectasComponent implements OnInit {
   // ─── Navegación ──────────────────────────────────────────────────────────────
 
   viewDetail(e: any): void {
+    // Una fila de depósito apunta al reporte (su _id es el id de la rendición),
+    // no a un gasto: navega al detalle de la rendición directa.
+    if (this.isDeposito(e)) {
+      this.router.navigate(['/mis-rendiciones', String(e._id), 'detalle']);
+      return;
+    }
     this.router.navigate(['/mis-rendiciones/gasto', String(e._id)]);
   }
 
@@ -208,7 +275,11 @@ export class RendicionesDirectasComponent implements OnInit {
     return {};
   }
 
+  /** Fila placeholder que representa una directa con depósito sin comprobantes aún. */
+  isDeposito(e: any): boolean { return e?._isDepositPlaceholder === true; }
+
   getTypeKey(e: any): string {
+    if (this.isDeposito(e)) return 'directa_deposito';
     const t = e?.expenseType;
     if (t === 'planilla_movilidad') return 'planilla_movilidad';
     if (t === 'otros_gastos') return 'otros_gastos';
@@ -218,6 +289,7 @@ export class RendicionesDirectasComponent implements OnInit {
   }
 
   getTypeCode(e: any): string {
+    if (this.isDeposito(e)) return 'DEP';
     const type = e?.expenseType;
     if (type === 'planilla_movilidad') return 'PM';
     if (type === 'comprobante_caja') return 'CC';
@@ -241,6 +313,7 @@ export class RendicionesDirectasComponent implements OnInit {
 
   getTypeBadgeClass(e: any): string {
     const code = this.getTypeCode(e);
+    if (code === 'DEP') return 'bg-emerald-100 text-emerald-700';
     if (code === 'PM') return 'bg-yellow-100 text-yellow-800';
     if (code === 'CC') return 'bg-purple-100 text-purple-800';
     if (code === 'SC' || code === 'OT') return 'bg-gray-100 text-gray-600';
@@ -257,6 +330,24 @@ export class RendicionesDirectasComponent implements OnInit {
   }
 
   getRendicionTitle(e: any): string { return e._report?.motivo || e._report?.title || '—'; }
+
+  /** Nombre del usuario que generó la rendición directa (createdBy del reporte). */
+  getGeneradoPor(e: any): string { return e._report?._generatedByName || '—'; }
+
+  /** Origen/tipo de la rendición directa: Contabilidad, Coordinador o Colaborador. */
+  getOrigen(e: any): string { return e._report?._origin || 'colaborador'; }
+
+  getOrigenLabel(e: any): string {
+    const labels: Record<string, string> = { contabilidad: 'Contabilidad', coordinador: 'Coordinador', colaborador: 'Colaborador' };
+    return labels[this.getOrigen(e)] ?? 'Colaborador';
+  }
+
+  getOrigenBadgeClass(e: any): string {
+    const o = this.getOrigen(e);
+    if (o === 'contabilidad') return 'bg-blue-100 text-blue-700';
+    if (o === 'coordinador') return 'bg-purple-100 text-purple-700';
+    return 'bg-gray-100 text-gray-600';
+  }
 
   getProject(e: any): string {
     const p = e._projectDoc || e._project?.[0];
@@ -307,6 +398,7 @@ export class RendicionesDirectasComponent implements OnInit {
   }
 
   getConcepto(e: any): string {
+    if (this.isDeposito(e)) return e?.description || 'Depósito de saldo';
     const type = e?.expenseType;
     if (type === 'planilla_movilidad') { const rows: any[] = e?.mobilityRows || []; const first = rows[0]; return first?.gestion || `${rows.length} filas`; }
     if (type === 'otros_gastos') return e?.description || 'DJ firmada';
@@ -316,6 +408,7 @@ export class RendicionesDirectasComponent implements OnInit {
   }
 
   getFecha(e: any): string {
+    if (this.isDeposito(e)) return e.fechaEmision || formatFechaEmisionDdMmYyyy(e.createdAt) || '—';
     const type = e?.expenseType;
     if (type === 'planilla_movilidad') { const rows: any[] = e?.mobilityRows || []; const dates = rows.map((r: any) => r.fecha).filter(Boolean); return dates.length ? ([...dates].sort()[0]) : '—'; }
     if (type === 'otros_gastos') return e.fechaEmision || formatFechaEmisionDdMmYyyy(e.createdAt) || '—';
@@ -356,7 +449,7 @@ export class RendicionesDirectasComponent implements OnInit {
   getEstadoContClass(e: any): string { return e.approvalCont?.status === 'approved' ? 'bg-teal-100 text-teal-700' : 'bg-yellow-100 text-yellow-700'; }
   isRevisado(e: any): boolean { return e.approvalCont?.status === 'approved'; }
   getTotal(e: any): number { const t = e?.total; if (typeof t === 'number') return t; const n = Number(t); return Number.isNaN(n) ? 0 : n; }
-  get totalMonto(): number { return this.data().reduce((sum, e) => sum + this.getTotal(e), 0); }
+  get totalMonto(): number { return this.data().reduce((sum, e) => sum + (this.isDeposito(e) ? 0 : this.getTotal(e)), 0); }
 
   private mapExpenseStatus(status?: string): string {
     const s = String(status || 'pending').toLowerCase();

--- a/src/app/services/expense-reports.service.ts
+++ b/src/app/services/expense-reports.service.ts
@@ -225,4 +225,18 @@ export class ExpenseReportsService {
       { params }
     );
   }
+
+  /** Rendiciones directas a nivel de reporte (una fila por rendición) para la pestaña "Rendiciones directas". */
+  findDirectRendicionReports(clientId: string, filters: {
+    dateFrom?: string; dateTo?: string; userId?: string;
+  } = {}): Observable<any[]> {
+    let params = new HttpParams();
+    if (filters.dateFrom) params = params.set('dateFrom', filters.dateFrom);
+    if (filters.dateTo) params = params.set('dateTo', filters.dateTo);
+    if (filters.userId) params = params.set('userId', filters.userId);
+    return this.http.get<any[]>(
+      `${this.apiUrl}/expense-report/directas/reports/${clientId}`,
+      { params }
+    );
+  }
 }


### PR DESCRIPTION
…na "Generado por"

- /rendiciones-directas: pestaña "Rendiciones directas" (una fila por rendición con generado por, origen, depósito/saldo) y pestaña "Gastos" (vista por comprobante de siempre) con nueva columna "Generado por".
- /rendiciones: se excluyen las rendiciones directas (solo rendiciones con solicitud).
- Nuevo método de servicio findDirectRendicionReports.