### PR TITLE
feat(rendiciones): escaneo OCR del comprobante de devolucion y reembolso

### DIFF
--- a/src/app/interfaces/advance.interface.ts
+++ b/src/app/interfaces/advance.interface.ts
@@ -88,6 +88,11 @@ export interface IReturnProof {
   fileKey?: string;
   uploadedAt: string;
   note?: string;
+  /** Datos extraídos del comprobante por OCR/visión (informativos). */
+  scannedAmount?: number;
+  operationDate?: string;
+  operationTime?: string;
+  titular?: string;
 }
 
 export interface IReturnValidation {

--- a/src/app/interfaces/expense-report.interface.ts
+++ b/src/app/interfaces/expense-report.interface.ts
@@ -41,6 +41,12 @@ export interface IReimbursementPaymentInfo {
   paymentReceiptFileName?: string;
   paymentReceiptMimeType?: string;
   paymentReceiptSizeBytes?: number;
+  /** Datos extraídos del comprobante por OCR/visión (informativos). */
+  scannedAmount?: number;
+  operationNumber?: string;
+  operationDate?: string;
+  operationTime?: string;
+  titular?: string;
 }
 
 export interface IExpenseReport {
@@ -78,6 +84,11 @@ export interface IExpenseReport {
     depositDate: string;
     bankOrigin?: string;
     operationNumber?: string;
+    /** Datos extraídos del comprobante por OCR/visión (informativos). */
+    scannedAmount?: number;
+    operationDate?: string;
+    operationTime?: string;
+    titular?: string;
     uploadedAt: string;
   };
   closureRecord?: IClosureRecord;
@@ -153,6 +164,12 @@ export interface IRegisterReimbursementPaymentPayload {
   paymentReceiptFileName?: string;
   paymentReceiptMimeType?: string;
   paymentReceiptSizeBytes?: number;
+  /** Datos extraídos del comprobante por OCR/visión (informativos). */
+  scannedAmount?: number;
+  operationNumber?: string;
+  operationDate?: string;
+  operationTime?: string;
+  titular?: string;
 }
 
 export interface IMisDocumentoItem {

--- a/src/app/modules/mis-rendiciones/rendicion-detail/rendicion-detail.component.html
+++ b/src/app/modules/mis-rendiciones/rendicion-detail/rendicion-detail.component.html
@@ -827,6 +827,22 @@
         <p class="text-sm text-gray-700 mb-3">
           El pago al colaborador fue registrado por tesorería.
         </p>
+        @if (report.reimbursementPaymentInfo.titular || report.reimbursementPaymentInfo.operationNumber || report.reimbursementPaymentInfo.operationDate || report.reimbursementPaymentInfo.scannedAmount) {
+        <div class="text-sm text-gray-700 space-y-1 mb-3">
+          @if (report.reimbursementPaymentInfo.titular) {
+            <p><span class="text-gray-500">Titular:</span> {{ report.reimbursementPaymentInfo.titular }}</p>
+          }
+          @if (report.reimbursementPaymentInfo.operationNumber) {
+            <p><span class="text-gray-500">N° Operación:</span> {{ report.reimbursementPaymentInfo.operationNumber }}</p>
+          }
+          @if (report.reimbursementPaymentInfo.operationDate) {
+            <p><span class="text-gray-500">Fecha/hora operación:</span> {{ report.reimbursementPaymentInfo.operationDate }}@if (report.reimbursementPaymentInfo.operationTime) { · {{ report.reimbursementPaymentInfo.operationTime }} }</p>
+          }
+          @if (report.reimbursementPaymentInfo.scannedAmount) {
+            <p><span class="text-gray-500">Monto detectado:</span> S/ {{ report.reimbursementPaymentInfo.scannedAmount | number:'1.2-2' }}</p>
+          }
+        </div>
+        }
         <div class="flex flex-wrap gap-3 text-sm">
           <a [href]="report.reimbursementPaymentInfo.paymentReceiptUrl" target="_blank" rel="noopener noreferrer"
             class="inline-flex items-center px-4 py-2 rounded-lg bg-emerald-700 text-white font-semibold hover:bg-emerald-800">
@@ -857,6 +873,15 @@
           }
           @if (report.returnVoucher.operationNumber) {
             <p><span class="text-gray-500">N° Operación:</span> {{ report.returnVoucher.operationNumber }}</p>
+          }
+          @if (report.returnVoucher.titular) {
+            <p><span class="text-gray-500">Titular:</span> {{ report.returnVoucher.titular }}</p>
+          }
+          @if (report.returnVoucher.operationDate) {
+            <p><span class="text-gray-500">Fecha/hora operación:</span> {{ report.returnVoucher.operationDate }}@if (report.returnVoucher.operationTime) { · {{ report.returnVoucher.operationTime }} }</p>
+          }
+          @if (report.returnVoucher.scannedAmount) {
+            <p><span class="text-gray-500">Monto detectado:</span> S/ {{ report.returnVoucher.scannedAmount | number:'1.2-2' }}</p>
           }
           <p><span class="text-gray-500">Enviado el:</span> {{ report.returnVoucher.uploadedAt | date:'dd/MM/yyyy HH:mm' }}</p>
         </div>
@@ -2829,6 +2854,44 @@
 
     <div class="space-y-3">
       <div>
+        <label class="block text-xs font-medium text-gray-700 mb-1">Comprobante (PDF, JPG, PNG — máx 10MB) *</label>
+        @if (returnVoucherFileName()) {
+          <p class="text-xs text-green-600 font-medium mb-1">Archivo cargado: {{ returnVoucherFileName() }}</p>
+        }
+        <label class="flex items-center gap-2 cursor-pointer px-3 py-2 border border-dashed border-gray-300 rounded-lg text-sm text-gray-600 hover:bg-gray-50 transition-colors">
+          <input type="file" accept=".pdf,.jpg,.jpeg,.png" class="hidden" (change)="onReturnVoucherFileSelected($event)">
+          @if (isUploadingReturnVoucher()) {
+            <span class="inline-block w-4 h-4 border-2 border-gray-400/40 border-t-gray-700 rounded-full animate-spin"></span>
+            Subiendo...
+          } @else {
+            Seleccionar archivo
+          }
+        </label>
+        @if (isScanningReturnVoucher()) {
+          <p class="text-xs text-gray-500 flex items-center gap-1.5 mt-1">
+            <span class="inline-block w-3 h-3 border-2 border-gray-400 border-t-transparent rounded-full animate-spin"></span>
+            Escaneando comprobante...
+          </p>
+        }
+      </div>
+      @if (returnVoucherHasDetectedData) {
+      <div class="rounded-lg border border-gray-200 bg-gray-50 p-3 space-y-1.5">
+        <p class="text-[11px] font-semibold text-gray-500 uppercase tracking-wider">Datos detectados del comprobante</p>
+        @if (returnVoucherTitular()) {
+        <div class="flex justify-between gap-3 text-xs"><span class="text-gray-400">Titular</span><span class="font-medium text-gray-700 text-right">{{ returnVoucherTitular() }}</span></div>
+        }
+        @if (returnVoucherOperationDate()) {
+        <div class="flex justify-between gap-3 text-xs"><span class="text-gray-400">Fecha</span><span class="font-medium text-gray-700 text-right">{{ returnVoucherOperationDate() }}</span></div>
+        }
+        @if (returnVoucherOperationTime()) {
+        <div class="flex justify-between gap-3 text-xs"><span class="text-gray-400">Hora</span><span class="font-medium text-gray-700 text-right">{{ returnVoucherOperationTime() }}</span></div>
+        }
+        @if (returnVoucherScannedAmount()) {
+        <div class="flex justify-between gap-3 text-xs"><span class="text-gray-400">Monto</span><span class="font-medium text-gray-700 text-right">S/ {{ returnVoucherScannedAmount() | number:'1.2-2' }}</span></div>
+        }
+      </div>
+      }
+      <div>
         <label class="block text-xs font-medium text-gray-700 mb-1">Fecha del depósito *</label>
         <input type="date" [value]="returnVoucherDepositDate()"
           (input)="returnVoucherDepositDate.set($any($event.target).value)"
@@ -2848,21 +2911,6 @@
           (input)="returnVoucherOperation.set($any($event.target).value)"
           placeholder="Número de operación o referencia"
           class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-red-500" />
-      </div>
-      <div>
-        <label class="block text-xs font-medium text-gray-700 mb-1">Comprobante (PDF, JPG, PNG — máx 10MB) *</label>
-        @if (returnVoucherFileName()) {
-          <p class="text-xs text-green-600 font-medium mb-1">Archivo cargado: {{ returnVoucherFileName() }}</p>
-        }
-        <label class="flex items-center gap-2 cursor-pointer px-3 py-2 border border-dashed border-gray-300 rounded-lg text-sm text-gray-600 hover:bg-gray-50 transition-colors">
-          <input type="file" accept=".pdf,.jpg,.jpeg,.png" class="hidden" (change)="onReturnVoucherFileSelected($event)">
-          @if (isUploadingReturnVoucher()) {
-            <span class="inline-block w-4 h-4 border-2 border-gray-400/40 border-t-gray-700 rounded-full animate-spin"></span>
-            Subiendo...
-          } @else {
-            Seleccionar archivo
-          }
-        </label>
       </div>
     </div>
 
@@ -2896,6 +2944,51 @@
 
     <div class="space-y-3">
       <div>
+        <label class="block text-xs font-medium text-gray-700 mb-1">
+          Comprobante (PDF, JPG, PNG — máx 10MB)
+          @if (adminReembolsoMethod() !== 'efectivo') {
+            *
+          } @else {
+            <span class="text-gray-400 font-normal">(opcional)</span>
+          }
+        </label>
+        @if (adminReembolsoFileName()) {
+          <p class="text-xs text-green-600 font-medium mb-1">Archivo cargado: {{ adminReembolsoFileName() }}</p>
+        }
+        <label class="flex items-center gap-2 cursor-pointer px-3 py-2 border border-dashed border-gray-300 rounded-lg text-sm text-gray-600 hover:bg-gray-50 transition-colors">
+          <input type="file" accept=".pdf,.jpg,.jpeg,.png" class="hidden" (change)="onAdminReembolsoFileSelected($event)">
+          @if (isUploadingAdminReembolso()) {
+            <span class="inline-block w-4 h-4 border-2 border-gray-400/40 border-t-gray-700 rounded-full animate-spin"></span>
+            Subiendo...
+          } @else {
+            Seleccionar archivo
+          }
+        </label>
+        @if (isScanningAdminReembolso()) {
+          <p class="text-xs text-gray-500 flex items-center gap-1.5 mt-1">
+            <span class="inline-block w-3 h-3 border-2 border-gray-400 border-t-transparent rounded-full animate-spin"></span>
+            Escaneando comprobante...
+          </p>
+        }
+      </div>
+      @if (adminReembolsoHasDetectedData) {
+      <div class="rounded-lg border border-gray-200 bg-gray-50 p-3 space-y-1.5">
+        <p class="text-[11px] font-semibold text-gray-500 uppercase tracking-wider">Datos detectados del comprobante</p>
+        @if (adminReembolsoTitular()) {
+        <div class="flex justify-between gap-3 text-xs"><span class="text-gray-400">Titular</span><span class="font-medium text-gray-700 text-right">{{ adminReembolsoTitular() }}</span></div>
+        }
+        @if (adminReembolsoOperationDate()) {
+        <div class="flex justify-between gap-3 text-xs"><span class="text-gray-400">Fecha</span><span class="font-medium text-gray-700 text-right">{{ adminReembolsoOperationDate() }}</span></div>
+        }
+        @if (adminReembolsoOperationTime()) {
+        <div class="flex justify-between gap-3 text-xs"><span class="text-gray-400">Hora</span><span class="font-medium text-gray-700 text-right">{{ adminReembolsoOperationTime() }}</span></div>
+        }
+        @if (adminReembolsoScannedAmount()) {
+        <div class="flex justify-between gap-3 text-xs"><span class="text-gray-400">Monto</span><span class="font-medium text-gray-700 text-right">S/ {{ adminReembolsoScannedAmount() | number:'1.2-2' }}</span></div>
+        }
+      </div>
+      }
+      <div>
         <label class="block text-xs font-medium text-gray-700 mb-1">Método de pago</label>
         <select [value]="adminReembolsoMethod()"
           (change)="adminReembolsoMethod.set($any($event.target).value)"
@@ -2924,28 +3017,6 @@
           (input)="adminReembolsoRef.set($any($event.target).value)"
           placeholder="Número de referencia"
           class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500" />
-      </div>
-      <div>
-        <label class="block text-xs font-medium text-gray-700 mb-1">
-          Comprobante (PDF, JPG, PNG — máx 10MB)
-          @if (adminReembolsoMethod() !== 'efectivo') {
-            *
-          } @else {
-            <span class="text-gray-400 font-normal">(opcional)</span>
-          }
-        </label>
-        @if (adminReembolsoFileName()) {
-          <p class="text-xs text-green-600 font-medium mb-1">Archivo cargado: {{ adminReembolsoFileName() }}</p>
-        }
-        <label class="flex items-center gap-2 cursor-pointer px-3 py-2 border border-dashed border-gray-300 rounded-lg text-sm text-gray-600 hover:bg-gray-50 transition-colors">
-          <input type="file" accept=".pdf,.jpg,.jpeg,.png" class="hidden" (change)="onAdminReembolsoFileSelected($event)">
-          @if (isUploadingAdminReembolso()) {
-            <span class="inline-block w-4 h-4 border-2 border-gray-400/40 border-t-gray-700 rounded-full animate-spin"></span>
-            Subiendo...
-          } @else {
-            Seleccionar archivo
-          }
-        </label>
       </div>
     </div>
 
@@ -2977,6 +3048,42 @@
     <h3 class="text-lg font-bold text-gray-900 mb-1">Cargar comprobante de deposito</h3>
     <p class="text-sm text-gray-500 mb-4">Adjunta el comprobante del deposito que realizaste para devolver el saldo del viático.</p>
     <div class="space-y-3">
+      <div class="flex flex-col gap-1">
+        <label class="text-xs font-medium text-gray-600">Comprobante adjunto <span class="text-red-500">*</span></label>
+        <input type="file" accept=".pdf,.jpg,.jpeg,.png"
+          (change)="onReturnProofFileSelected($event)"
+          class="w-full px-2 py-1.5 rounded-lg border border-gray-200 text-sm bg-white file:mr-2 file:px-2 file:py-1 file:rounded file:border-0 file:bg-gray-100 file:text-gray-700" />
+        @if (isUploadingReturnProof()) {
+        <p class="text-xs text-blue-600">Subiendo...</p>
+        } @else if (returnProofFileName()) {
+        <p class="text-xs text-green-700">Adjunto: {{ returnProofFileName() }}</p>
+        } @else {
+        <p class="text-xs text-gray-400">PDF/JPG/PNG (max 10MB)</p>
+        }
+        @if (isScanningReturnProof()) {
+          <p class="text-xs text-gray-500 flex items-center gap-1.5 mt-1">
+            <span class="inline-block w-3 h-3 border-2 border-gray-400 border-t-transparent rounded-full animate-spin"></span>
+            Escaneando comprobante...
+          </p>
+        }
+      </div>
+      @if (returnProofHasDetectedData) {
+      <div class="rounded-lg border border-gray-200 bg-gray-50 p-3 space-y-1.5">
+        <p class="text-[11px] font-semibold text-gray-500 uppercase tracking-wider">Datos detectados del comprobante</p>
+        @if (returnProofTitular()) {
+        <div class="flex justify-between gap-3 text-xs"><span class="text-gray-400">Titular</span><span class="font-medium text-gray-700 text-right">{{ returnProofTitular() }}</span></div>
+        }
+        @if (returnProofOperationDate()) {
+        <div class="flex justify-between gap-3 text-xs"><span class="text-gray-400">Fecha</span><span class="font-medium text-gray-700 text-right">{{ returnProofOperationDate() }}</span></div>
+        }
+        @if (returnProofOperationTime()) {
+        <div class="flex justify-between gap-3 text-xs"><span class="text-gray-400">Hora</span><span class="font-medium text-gray-700 text-right">{{ returnProofOperationTime() }}</span></div>
+        }
+        @if (returnProofScannedAmount()) {
+        <div class="flex justify-between gap-3 text-xs"><span class="text-gray-400">Monto</span><span class="font-medium text-gray-700 text-right">S/ {{ returnProofScannedAmount() | number:'1.2-2' }}</span></div>
+        }
+      </div>
+      }
       <div class="grid grid-cols-2 gap-3">
         <div class="flex flex-col gap-1">
           <label class="text-xs font-medium text-gray-600">Fecha de deposito <span class="text-red-500">*</span></label>
@@ -3003,19 +3110,6 @@
         <label class="text-xs font-medium text-gray-600">Nota (opcional)</label>
         <textarea [value]="returnProofNote()" (input)="returnProofNote.set($any($event.target).value)"
           rows="2" class="w-full px-3 py-2 rounded-lg border border-gray-200 text-sm resize-none"></textarea>
-      </div>
-      <div class="flex flex-col gap-1">
-        <label class="text-xs font-medium text-gray-600">Comprobante adjunto <span class="text-red-500">*</span></label>
-        <input type="file" accept=".pdf,.jpg,.jpeg,.png"
-          (change)="onReturnProofFileSelected($event)"
-          class="w-full px-2 py-1.5 rounded-lg border border-gray-200 text-sm bg-white file:mr-2 file:px-2 file:py-1 file:rounded file:border-0 file:bg-gray-100 file:text-gray-700" />
-        @if (isUploadingReturnProof()) {
-        <p class="text-xs text-blue-600">Subiendo...</p>
-        } @else if (returnProofFileName()) {
-        <p class="text-xs text-green-700">Adjunto: {{ returnProofFileName() }}</p>
-        } @else {
-        <p class="text-xs text-gray-400">PDF/JPG/PNG (max 10MB)</p>
-        }
       </div>
     </div>
     <div class="flex gap-3 mt-5">

--- a/src/app/modules/mis-rendiciones/rendicion-detail/rendicion-detail.component.ts
+++ b/src/app/modules/mis-rendiciones/rendicion-detail/rendicion-detail.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, inject, signal, computed, HostListener } from '@angular/core';
+import { Component, OnInit, inject, signal, computed, HostListener, WritableSignal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
@@ -1533,6 +1533,30 @@ export class RendicionDetailComponent implements OnInit {
       });
   }
 
+  /**
+   * Escanea (OCR/visión) un comprobante de depósito/transferencia ya subido y entrega
+   * monto, fecha, hora, n° de operación y titular. Reutiliza el mismo endpoint que el
+   * pago de anticipo y el depósito de rendición directa.
+   */
+  private scanComprobante(
+    url: string,
+    mimeType: string | undefined,
+    scanning: WritableSignal<boolean>,
+    onResult: (res: { amount: number; fecha?: string; hora?: string; operationNumber?: string; titular?: string }) => void
+  ): void {
+    scanning.set(true);
+    this.expenseReportsService.scanDepositAmount(url, mimeType).subscribe({
+      next: (res) => {
+        scanning.set(false);
+        onResult(res ?? { amount: 0 });
+      },
+      error: () => {
+        scanning.set(false);
+        this.notificationService.show('No se pudo escanear el comprobante. Completa los datos manualmente.', 'warning');
+      },
+    });
+  }
+
   // ─── Cierre: voucher de devolucion (colaborador) ──────────────────────────
 
   showReturnVoucherModal = signal(false);
@@ -1543,6 +1567,12 @@ export class RendicionDetailComponent implements OnInit {
   returnVoucherDepositDate = signal(new Date().toISOString().split('T')[0]);
   returnVoucherBank = signal('');
   returnVoucherOperation = signal('');
+  // Datos detectados por el escaneo del comprobante
+  isScanningReturnVoucher = signal(false);
+  returnVoucherScannedAmount = signal<number | null>(null);
+  returnVoucherTitular = signal<string | null>(null);
+  returnVoucherOperationDate = signal<string | null>(null);
+  returnVoucherOperationTime = signal<string | null>(null);
 
   /** Saldo de esta rendición ya fue utilizado para crear otra solicitud o rendición directa. */
   get isSaldoUsadoEnOtraRendicion(): boolean {
@@ -1607,7 +1637,15 @@ export class RendicionDetailComponent implements OnInit {
     this.returnVoucherDepositDate.set(new Date().toISOString().split('T')[0]);
     this.returnVoucherBank.set(this.getCollaboratorBankName() ?? '');
     this.returnVoucherOperation.set('');
+    this.returnVoucherScannedAmount.set(null);
+    this.returnVoucherTitular.set(null);
+    this.returnVoucherOperationDate.set(null);
+    this.returnVoucherOperationTime.set(null);
     this.showReturnVoucherModal.set(true);
+  }
+
+  get returnVoucherHasDetectedData(): boolean {
+    return !!(this.returnVoucherTitular() || this.returnVoucherOperationDate() || this.returnVoucherOperationTime() || this.returnVoucherScannedAmount());
   }
 
   onReturnVoucherFileSelected(event: Event): void {
@@ -1632,6 +1670,16 @@ export class RendicionDetailComponent implements OnInit {
         this.returnVoucherFileName.set(file.name);
         this.notificationService.show('Comprobante subido', 'success');
         this.isUploadingReturnVoucher.set(false);
+        this.scanComprobante(res.url, file.type, this.isScanningReturnVoucher, (r) => {
+          this.returnVoucherScannedAmount.set(Number(r.amount) > 0 ? Number(r.amount) : null);
+          this.returnVoucherTitular.set(r.titular || null);
+          this.returnVoucherOperationDate.set(r.fecha || null);
+          this.returnVoucherOperationTime.set(r.hora || null);
+          if (r.operationNumber && !this.returnVoucherOperation()) this.returnVoucherOperation.set(r.operationNumber);
+          if (this.returnVoucherHasDetectedData) {
+            this.notificationService.show('Datos detectados del comprobante.', 'success');
+          }
+        });
       },
       error: () => {
         this.notificationService.show('No se pudo subir el comprobante', 'error');
@@ -1653,6 +1701,10 @@ export class RendicionDetailComponent implements OnInit {
       operationNumber: this.returnVoucherOperation() || undefined,
       fileUrl,
       fileName: this.returnVoucherFileName() || undefined,
+      scannedAmount: this.returnVoucherScannedAmount() ?? undefined,
+      operationDate: this.returnVoucherOperationDate() || undefined,
+      operationTime: this.returnVoucherOperationTime() || undefined,
+      titular: this.returnVoucherTitular() || undefined,
     }).subscribe({
       next: (res) => {
         this.report = res;
@@ -1681,6 +1733,12 @@ export class RendicionDetailComponent implements OnInit {
   adminReembolsoBank = signal('');
   adminReembolsoRef = signal('');
   adminReembolsoMethod = signal<'transferencia_bancaria' | 'efectivo' | 'cheque'>('transferencia_bancaria');
+  // Datos detectados por el escaneo del comprobante
+  isScanningAdminReembolso = signal(false);
+  adminReembolsoScannedAmount = signal<number | null>(null);
+  adminReembolsoTitular = signal<string | null>(null);
+  adminReembolsoOperationDate = signal<string | null>(null);
+  adminReembolsoOperationTime = signal<string | null>(null);
 
   openAdminReembolsoModal(): void {
     this.adminReembolsoUrl.set(null);
@@ -1689,7 +1747,15 @@ export class RendicionDetailComponent implements OnInit {
     this.adminReembolsoBank.set('');
     this.adminReembolsoRef.set('');
     this.adminReembolsoMethod.set('transferencia_bancaria');
+    this.adminReembolsoScannedAmount.set(null);
+    this.adminReembolsoTitular.set(null);
+    this.adminReembolsoOperationDate.set(null);
+    this.adminReembolsoOperationTime.set(null);
     this.showAdminReembolsoModal.set(true);
+  }
+
+  get adminReembolsoHasDetectedData(): boolean {
+    return !!(this.adminReembolsoTitular() || this.adminReembolsoOperationDate() || this.adminReembolsoOperationTime() || this.adminReembolsoScannedAmount());
   }
 
   onAdminReembolsoFileSelected(event: Event): void {
@@ -1714,6 +1780,16 @@ export class RendicionDetailComponent implements OnInit {
         this.adminReembolsoFileName.set(file.name);
         this.notificationService.show('Comprobante subido', 'success');
         this.isUploadingAdminReembolso.set(false);
+        this.scanComprobante(res.url, file.type, this.isScanningAdminReembolso, (r) => {
+          this.adminReembolsoScannedAmount.set(Number(r.amount) > 0 ? Number(r.amount) : null);
+          this.adminReembolsoTitular.set(r.titular || null);
+          this.adminReembolsoOperationDate.set(r.fecha || null);
+          this.adminReembolsoOperationTime.set(r.hora || null);
+          if (r.operationNumber && !this.adminReembolsoRef()) this.adminReembolsoRef.set(r.operationNumber);
+          if (this.adminReembolsoHasDetectedData) {
+            this.notificationService.show('Datos detectados del comprobante.', 'success');
+          }
+        });
       },
       error: () => {
         this.notificationService.show('No se pudo subir el comprobante', 'error');
@@ -1741,6 +1817,11 @@ export class RendicionDetailComponent implements OnInit {
       reference: this.adminReembolsoRef() || undefined,
       paymentReceiptUrl: fileUrl || undefined,
       paymentReceiptFileName: this.adminReembolsoFileName() || undefined,
+      scannedAmount: this.adminReembolsoScannedAmount() ?? undefined,
+      operationNumber: this.adminReembolsoRef() || undefined,
+      operationDate: this.adminReembolsoOperationDate() || undefined,
+      operationTime: this.adminReembolsoOperationTime() || undefined,
+      titular: this.adminReembolsoTitular() || undefined,
     }).subscribe({
       next: (res) => {
         this.report = res;
@@ -1771,6 +1852,16 @@ export class RendicionDetailComponent implements OnInit {
   returnProofBank = signal('');
   returnProofOperation = signal('');
   returnProofNote = signal('');
+  // Datos detectados por el escaneo del comprobante
+  isScanningReturnProof = signal(false);
+  returnProofScannedAmount = signal<number | null>(null);
+  returnProofTitular = signal<string | null>(null);
+  returnProofOperationDate = signal<string | null>(null);
+  returnProofOperationTime = signal<string | null>(null);
+
+  get returnProofHasDetectedData(): boolean {
+    return !!(this.returnProofTitular() || this.returnProofOperationDate() || this.returnProofOperationTime() || this.returnProofScannedAmount());
+  }
 
   get advancesWithPendingReturn(): typeof this.advances {
     return this.advances.filter(
@@ -1807,6 +1898,10 @@ export class RendicionDetailComponent implements OnInit {
     this.returnProofBank.set(this.getCollaboratorBankName() ?? '');
     this.returnProofOperation.set('');
     this.returnProofNote.set('');
+    this.returnProofScannedAmount.set(null);
+    this.returnProofTitular.set(null);
+    this.returnProofOperationDate.set(null);
+    this.returnProofOperationTime.set(null);
     this.showReturnProofModal.set(true);
   }
 
@@ -1832,6 +1927,16 @@ export class RendicionDetailComponent implements OnInit {
         this.returnProofFileName.set(file.name);
         this.notificationService.show('Comprobante subido', 'success');
         this.isUploadingReturnProof.set(false);
+        this.scanComprobante(res.url, file.type, this.isScanningReturnProof, (r) => {
+          this.returnProofScannedAmount.set(Number(r.amount) > 0 ? Number(r.amount) : null);
+          this.returnProofTitular.set(r.titular || null);
+          this.returnProofOperationDate.set(r.fecha || null);
+          this.returnProofOperationTime.set(r.hora || null);
+          if (r.operationNumber && !this.returnProofOperation()) this.returnProofOperation.set(r.operationNumber);
+          if (this.returnProofHasDetectedData) {
+            this.notificationService.show('Datos detectados del comprobante.', 'success');
+          }
+        });
       },
       error: () => {
         this.notificationService.show('No se pudo subir el comprobante', 'error');
@@ -1856,6 +1961,10 @@ export class RendicionDetailComponent implements OnInit {
       operationNumber: this.returnProofOperation(),
       fileUrl,
       note: this.returnProofNote() || undefined,
+      scannedAmount: this.returnProofScannedAmount() ?? undefined,
+      operationDate: this.returnProofOperationDate() || undefined,
+      operationTime: this.returnProofOperationTime() || undefined,
+      titular: this.returnProofTitular() || undefined,
     }).subscribe({
       next: () => {
         this.notificationService.show('Comprobante enviado correctamente', 'success');

--- a/src/app/modules/tesoreria/tesoreria.component.html
+++ b/src/app/modules/tesoreria/tesoreria.component.html
@@ -651,6 +651,69 @@
 
       <form [formGroup]="paymentForm" class="space-y-4">
         <div class="flex flex-col gap-1.5">
+          <label class="text-xs font-semibold text-tertiary uppercase tracking-wider">
+            Comprobante
+            @if (paymentForm.get('method')?.value !== 'efectivo') {
+              <span class="text-error">*</span>
+            } @else {
+              <span class="text-tertiary normal-case font-normal">(opcional)</span>
+            }
+          </label>
+          @if (!reimbursementReceiptName) {
+          <label class="flex flex-col items-center justify-center gap-2 h-24 rounded-xl border-2 border-dashed border-tertiary/30 hover:border-primary/40 hover:bg-primary/5 cursor-pointer transition-colors">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-tertiary">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5" />
+            </svg>
+            <span class="text-xs text-tertiary">PDF, JPG o PNG (máx. 10MB)</span>
+            <input type="file" accept=".pdf,.jpg,.jpeg,.png,application/pdf,image/jpeg,image/png"
+              (change)="onReimbursementReceiptSelected($event)" class="hidden" />
+          </label>
+          } @else {
+          <div class="flex items-center gap-3 p-3 rounded-xl bg-green-50 border border-green-200">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-green-600 shrink-0">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+            </svg>
+            <span class="text-xs text-green-700 font-medium truncate flex-1">{{ reimbursementReceiptName }}</span>
+            <button type="button" (click)="reimbursementReceiptUrl=null; reimbursementReceiptName=null"
+              class="text-xs text-tertiary hover:text-error transition-colors shrink-0">Quitar</button>
+          </div>
+          }
+          @if (isUploadingReceipt()) {
+          <p class="text-xs text-primary flex items-center gap-1.5">
+            <span class="inline-block w-3 h-3 border-2 border-primary border-t-transparent rounded-full animate-spin"></span>
+            Subiendo comprobante...
+          </p>
+          }
+          @if (isScanningReimbursement()) {
+          <p class="text-xs text-primary flex items-center gap-1.5">
+            <span class="inline-block w-3 h-3 border-2 border-primary border-t-transparent rounded-full animate-spin"></span>
+            Escaneando comprobante...
+          </p>
+          }
+        </div>
+
+        @if (reimbursementOperationNumber || reimbursementOperationDate || reimbursementOperationTime || reimbursementTitular) {
+        <div class="rounded-xl border border-tertiary/20 bg-background/60 p-3 space-y-1.5">
+          <p class="text-[11px] font-semibold text-tertiary uppercase tracking-wider">Datos detectados del comprobante</p>
+          @if (reimbursementTitular) {
+          <div class="flex justify-between gap-3 text-xs"><span class="text-tertiary">Titular</span><span class="font-medium text-secondary text-right">{{ reimbursementTitular }}</span></div>
+          }
+          @if (reimbursementOperationNumber) {
+          <div class="flex justify-between gap-3 text-xs"><span class="text-tertiary">N° operación</span><span class="font-medium text-secondary text-right">{{ reimbursementOperationNumber }}</span></div>
+          }
+          @if (reimbursementOperationDate) {
+          <div class="flex justify-between gap-3 text-xs"><span class="text-tertiary">Fecha</span><span class="font-medium text-secondary text-right">{{ reimbursementOperationDate }}</span></div>
+          }
+          @if (reimbursementOperationTime) {
+          <div class="flex justify-between gap-3 text-xs"><span class="text-tertiary">Hora</span><span class="font-medium text-secondary text-right">{{ reimbursementOperationTime }}</span></div>
+          }
+          @if (reimbursementScannedAmount !== null) {
+          <div class="flex justify-between gap-3 text-xs"><span class="text-tertiary">Monto</span><span class="font-medium text-secondary text-right">S/ {{ reimbursementScannedAmount | number:'1.2-2' }}</span></div>
+          }
+        </div>
+        }
+
+        <div class="flex flex-col gap-1.5">
           <label class="text-xs font-semibold text-tertiary uppercase tracking-wider">Método de pago</label>
           <select formControlName="method"
             class="w-full h-[42px] px-3 rounded-xl border border-tertiary/30 text-sm text-secondary bg-quaternary focus:outline-none focus:ring-2 focus:ring-primary/30">
@@ -689,42 +752,6 @@
             <input type="text" formControlName="reference"
               class="w-full h-[42px] px-3 rounded-xl border border-tertiary/30 text-sm text-secondary bg-quaternary focus:outline-none focus:ring-2 focus:ring-primary/30" />
           </div>
-        </div>
-
-        <div class="flex flex-col gap-1.5">
-          <label class="text-xs font-semibold text-tertiary uppercase tracking-wider">
-            Comprobante
-            @if (paymentForm.get('method')?.value !== 'efectivo') {
-              <span class="text-error">*</span>
-            } @else {
-              <span class="text-tertiary normal-case font-normal">(opcional)</span>
-            }
-          </label>
-          @if (!reimbursementReceiptName) {
-          <label class="flex flex-col items-center justify-center gap-2 h-24 rounded-xl border-2 border-dashed border-tertiary/30 hover:border-primary/40 hover:bg-primary/5 cursor-pointer transition-colors">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 text-tertiary">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5" />
-            </svg>
-            <span class="text-xs text-tertiary">PDF, JPG o PNG (máx. 10MB)</span>
-            <input type="file" accept=".pdf,.jpg,.jpeg,.png,application/pdf,image/jpeg,image/png"
-              (change)="onReimbursementReceiptSelected($event)" class="hidden" />
-          </label>
-          } @else {
-          <div class="flex items-center gap-3 p-3 rounded-xl bg-green-50 border border-green-200">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-green-600 shrink-0">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
-            </svg>
-            <span class="text-xs text-green-700 font-medium truncate flex-1">{{ reimbursementReceiptName }}</span>
-            <button type="button" (click)="reimbursementReceiptUrl=null; reimbursementReceiptName=null"
-              class="text-xs text-tertiary hover:text-error transition-colors shrink-0">Quitar</button>
-          </div>
-          }
-          @if (isUploadingReceipt()) {
-          <p class="text-xs text-primary flex items-center gap-1.5">
-            <span class="inline-block w-3 h-3 border-2 border-primary border-t-transparent rounded-full animate-spin"></span>
-            Subiendo comprobante...
-          </p>
-          }
         </div>
       </form>
 

--- a/src/app/modules/tesoreria/tesoreria.component.ts
+++ b/src/app/modules/tesoreria/tesoreria.component.ts
@@ -49,6 +49,13 @@ export class TesoreriaComponent implements OnInit {
   reimbursementReceiptName: string | null = null;
   reimbursementReceiptMimeType: string | null = null;
   reimbursementReceiptSizeBytes: number | null = null;
+  // Reembolso: escaneo del comprobante (OCR) — solo autocompleta, sin alerta
+  isScanningReimbursement = signal(false);
+  reimbursementScannedAmount: number | null = null;
+  reimbursementTitular: string | null = null;
+  reimbursementOperationNumber: string | null = null;
+  reimbursementOperationDate: string | null = null;
+  reimbursementOperationTime: string | null = null;
   showPaymentModal = false;
   showRejectModal = false;
   showReturnModal = false;
@@ -427,6 +434,7 @@ export class TesoreriaComponent implements OnInit {
     this.reimbursementReceiptName = null;
     this.reimbursementReceiptMimeType = null;
     this.reimbursementReceiptSizeBytes = null;
+    this.resetReimbursementScanState();
     const user = typeof report.userId === 'object' ? report.userId : null;
     const bankAccount = user && typeof user === 'object' && 'bankAccount' in user
       ? (user as { bankAccount?: { bankName?: string; accountNumber?: string; cci?: string } }).bankAccount
@@ -465,10 +473,42 @@ export class TesoreriaComponent implements OnInit {
         this.reimbursementReceiptSizeBytes = file.size;
         this.notificationService.show('Comprobante cargado correctamente', 'success');
         this.isUploadingReceipt.set(false);
+        this.scanReimbursementReceipt(res.url, file.type);
       },
       error: () => {
         this.notificationService.show('No se pudo subir el comprobante', 'error');
         this.isUploadingReceipt.set(false);
+      },
+    });
+  }
+
+  private resetReimbursementScanState(): void {
+    this.reimbursementScannedAmount = null;
+    this.reimbursementTitular = null;
+    this.reimbursementOperationNumber = null;
+    this.reimbursementOperationDate = null;
+    this.reimbursementOperationTime = null;
+  }
+
+  /** Escanea el comprobante del reembolso y autocompleta los datos (sin alerta de discrepancia). */
+  private scanReimbursementReceipt(url: string, mimeType?: string): void {
+    this.isScanningReimbursement.set(true);
+    this.expenseReportsService.scanDepositAmount(url, mimeType).subscribe({
+      next: res => {
+        this.isScanningReimbursement.set(false);
+        const amount = Number(res?.amount) || 0;
+        this.reimbursementScannedAmount = amount > 0 ? amount : null;
+        this.reimbursementTitular = res?.titular || null;
+        this.reimbursementOperationNumber = res?.operationNumber || null;
+        this.reimbursementOperationDate = res?.fecha || null;
+        this.reimbursementOperationTime = res?.hora || null;
+        if (res?.operationNumber && !this.paymentForm.value.reference) {
+          this.paymentForm.patchValue({ reference: res.operationNumber });
+        }
+      },
+      error: () => {
+        this.isScanningReimbursement.set(false);
+        this.notificationService.show('No se pudo escanear el comprobante. Completa los datos manualmente.', 'warning');
       },
     });
   }
@@ -488,6 +528,11 @@ export class TesoreriaComponent implements OnInit {
         paymentReceiptFileName: this.reimbursementReceiptName || undefined,
         paymentReceiptMimeType: this.reimbursementReceiptMimeType || undefined,
         paymentReceiptSizeBytes: this.reimbursementReceiptSizeBytes || undefined,
+        scannedAmount: this.reimbursementScannedAmount ?? undefined,
+        operationNumber: this.reimbursementOperationNumber || this.paymentForm.value.reference || undefined,
+        operationDate: this.reimbursementOperationDate || undefined,
+        operationTime: this.reimbursementOperationTime || undefined,
+        titular: this.reimbursementTitular || undefined,
       })
       .subscribe({
         next: () => {

--- a/src/app/services/expense-reports.service.ts
+++ b/src/app/services/expense-reports.service.ts
@@ -150,7 +150,17 @@ export class ExpenseReportsService {
 
   registerReturnVoucher(
     reportId: string,
-    payload: { depositDate: string; bankOrigin?: string; operationNumber?: string; fileUrl: string; fileName?: string }
+    payload: {
+      depositDate: string;
+      bankOrigin?: string;
+      operationNumber?: string;
+      fileUrl: string;
+      fileName?: string;
+      scannedAmount?: number;
+      operationDate?: string;
+      operationTime?: string;
+      titular?: string;
+    }
   ): Observable<IExpenseReport> {
     return this.http.post<IExpenseReport>(
       `${this.apiUrl}/expense-report/${reportId}/return-voucher`,


### PR DESCRIPTION
Al subir el comprobante de devolucion (colaborador) o reembolso (contabilidad) en viaticos y rendicion directa, ahora se escanea automaticamente y se autocompletan/guardan fecha, hora, n de operacion, monto y titular, reutilizando el endpoint scan-deposit-amount ya existente. El selector de archivo se movio al inicio de cada modal para que el escaneo rellene los campos siguientes. Sin alerta de discrepancia y sin modificar el pago de anticipo.