### PR TITLE
feat(caja-chica): ocultar "Anadir Gasto" si la caja chica fue finalizada

### DIFF
--- a/src/app/interfaces/expense-report.interface.ts
+++ b/src/app/interfaces/expense-report.interface.ts
@@ -104,6 +104,11 @@ export interface IExpenseReport {
   gestion?: string;
   isDirecta?: boolean;
   isCajaChica?: boolean;
+  /**
+   * Derivado en backend: la caja chica que incluye esta rendición ya fue
+   * finalizada por Contabilidad, por lo que el colaborador no puede subir más gastos.
+   */
+  lockedByCajaChica?: boolean;
   /** Depósito inicial cuando la rendición directa fue iniciada por Contabilidad. */
   directaDeposit?: IDirectaDepositInfo;
   /** ID de la rendición directa de la que proviene el saldo heredado. */

--- a/src/app/modules/mis-rendiciones/rendicion-detail/rendicion-detail.component.html
+++ b/src/app/modules/mis-rendiciones/rendicion-detail/rendicion-detail.component.html
@@ -281,6 +281,13 @@
         </div>
         }
 
+        <!-- Colaborador: caja chica finalizada por Contabilidad -->
+        @if (!isAdminView && report.isCajaChica && report.lockedByCajaChica) {
+        <p class="max-w-xs text-xs text-emerald-700 bg-emerald-50 border border-emerald-200 rounded-lg px-3 py-2">
+          La caja chica fue finalizada por Contabilidad. Ya no puedes agregar más gastos a esta rendición.
+        </p>
+        }
+
         <!-- Colaborador: abierta sin pago registrado (solo aplica a rendiciones con anticipo) -->
         @if (!isAdminView && report.status === 'open' && !hasPaidAdvanceForReport && !report.isDirecta && !report.isCajaChica) {
         <p class="max-w-xs text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2">

--- a/src/app/modules/mis-rendiciones/rendicion-detail/rendicion-detail.component.ts
+++ b/src/app/modules/mis-rendiciones/rendicion-detail/rendicion-detail.component.ts
@@ -385,6 +385,9 @@ export class RendicionDetailComponent implements OnInit {
   get canAddExpenses(): boolean {
     if (!this.report || this.isAdminView) return false;
     if (this.report.status !== 'open') return false;
+    // Caja chica finalizada por Contabilidad: el total quedó congelado, no se
+    // pueden subir más gastos a esta rendición.
+    if (this.report.lockedByCajaChica) return false;
     // Rendición directa: no necesita anticipo pagado para agregar gastos
     if (this.report.isDirecta || this.report.isCajaChica) return true;
     return this.hasPaidAdvanceForReport;


### PR DESCRIPTION
- IExpenseReport.lockedByCajaChica (derivado del backend).
- canAddExpenses devuelve false cuando lockedByCajaChica es true.
- Mensaje informativo en el detalle de la rendicion.