### PR TITLE
feat(mis-rendiciones): ocultar borrar en directas/caja chica restring…

### DIFF
--- a/src/app/interfaces/expense-report.interface.ts
+++ b/src/app/interfaces/expense-report.interface.ts
@@ -102,6 +102,24 @@ export interface IExpenseReport {
    * eliminar la solicitud.
    */
   hasApprovedExpense?: boolean;
+  /**
+   * Derivado en backend: la solicitud la creó alguien distinto del dueño (ej.
+   * Contabilidad creó la rendición directa para el colaborador). Si es true, el
+   * dueño no puede eliminarla; solo Contabilidad.
+   */
+  createdByOther?: boolean;
+  /**
+   * Derivado en backend: la rendición directa se creó con saldo heredado de otra
+   * rendición. Si es true, el dueño no puede eliminarla (rompería la cadena del
+   * saldo); solo Contabilidad.
+   */
+  inheritedBalance?: boolean;
+  /**
+   * Derivado en backend: la caja chica ya fue incluida (jalada) por Contabilidad
+   * en un reporte (borrador o finalizado). Si es true, el colaborador ya no puede
+   * eliminarla; solo Contabilidad.
+   */
+  referencedByCajaChica?: boolean;
   reopenHistory?: Array<{ reason: string; reopenedBy: string; reopenedAt: string; fromStatus: string }>;
   motivo?: string;
   /** Código autoincremental único de la rendición directa (ej. RD-0001). */

--- a/src/app/modules/mis-rendiciones/mis-rendiciones.component.ts
+++ b/src/app/modules/mis-rendiciones/mis-rendiciones.component.ts
@@ -603,12 +603,20 @@ export class MisRendicionesComponent implements OnInit {
     const noReportApproval =
       !report.coordinatorApprovedBy && !report.contabilidadApprovedBy;
     const noExpenseApproval = !report.hasApprovedExpense;
+    if (!noReportApproval || !noExpenseApproval) return false;
+
+    // Rendición directa creada por Contabilidad para el colaborador, o creada con
+    // saldo heredado de otra: no la puede eliminar (solo Contabilidad).
+    if (report.isDirecta && (report.createdByOther || report.inheritedBalance))
+      return false;
+
+    // Caja chica ya jalada por Contabilidad (borrador o finalizado): no la puede
+    // eliminar (solo Contabilidad).
+    if (report.isCajaChica && (report.referencedByCajaChica || report.lockedByCajaChica))
+      return false;
+
     const deletableStatuses = ['solicited', 'open', 'rejected', 'submitted'];
-    return (
-      noReportApproval &&
-      noExpenseApproval &&
-      deletableStatuses.includes(report.status)
-    );
+    return deletableStatuses.includes(report.status);
   }
 
   openDeleteReportModal(report: IExpenseReport, event: Event): void {


### PR DESCRIPTION
…idas

canDeleteReport oculta el boton de eliminar cuando la directa fue creada por Contabilidad para el colaborador (createdByOther) o se creo con saldo heredado (inheritedBalance), y cuando la caja chica ya fue jalada por Contabilidad (referencedByCajaChica). Espeja la validacion del backend.