### PR TITLE
feat(viaticos): detalle de categorias al aprobar, viaticos pagados en…

### DIFF
--- a/src/app/modules/admin-users/rendiciones-admin/rendiciones-admin.component.html
+++ b/src/app/modules/admin-users/rendiciones-admin/rendiciones-admin.component.html
@@ -325,7 +325,7 @@
 @if (showApproveModal()) {
   <div class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-secondary/50 backdrop-blur-sm"
        (click)="showApproveModal.set(false)">
-    <div class="bg-quaternary rounded-2xl shadow-xl border border-tertiary/20 w-full max-w-sm p-6"
+    <div class="bg-quaternary rounded-2xl shadow-xl border border-tertiary/20 w-full max-w-lg p-6 max-h-[90vh] overflow-y-auto"
          (click)="$event.stopPropagation()">
       <div class="flex items-center gap-3 mb-5">
         <div class="w-11 h-11 rounded-xl flex items-center justify-center shrink-0"
@@ -361,6 +361,38 @@
           <span class="text-lg font-bold text-secondary tabular-nums">S/ {{ pendingApproveItem()?.amount | number:'1.2-2' }}</span>
         </div>
       </div>
+      @if (approveViaticoLines().length > 0) {
+      <div class="mb-5">
+        <p class="text-xs font-semibold text-tertiary uppercase tracking-wider mb-2">Detalle por categoría</p>
+        <div class="rounded-xl border border-tertiary/15 overflow-hidden">
+          <table class="min-w-full text-xs">
+            <thead class="bg-background">
+              <tr>
+                <th class="px-3 py-2 text-left font-semibold text-tertiary">Categoría</th>
+                <th class="px-3 py-2 text-right font-semibold text-tertiary">Importe</th>
+                <th class="px-3 py-2 text-right font-semibold text-tertiary">Pers.</th>
+                <th class="px-3 py-2 text-right font-semibold text-tertiary">Días</th>
+                <th class="px-3 py-2 text-right font-semibold text-tertiary">Total</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-tertiary/10">
+              @for (ln of approveViaticoLines(); track $index) {
+              <tr>
+                <td class="px-3 py-2 text-secondary">
+                  {{ viaticoCategoryName(ln) }}
+                  @if (ln.detalle) { <span class="block text-tertiary">{{ ln.detalle }}</span> }
+                </td>
+                <td class="px-3 py-2 text-right text-secondary tabular-nums">S/ {{ ln.importe | number:'1.2-2' }}</td>
+                <td class="px-3 py-2 text-right text-secondary tabular-nums">{{ ln.peopleCount }}</td>
+                <td class="px-3 py-2 text-right text-secondary tabular-nums">{{ ln.days }}</td>
+                <td class="px-3 py-2 text-right font-semibold text-secondary tabular-nums">S/ {{ ln.lineTotal | number:'1.2-2' }}</td>
+              </tr>
+              }
+            </tbody>
+          </table>
+        </div>
+      </div>
+      }
       <div class="flex gap-3">
         <button (click)="showApproveModal.set(false)"
           class="flex-1 h-10 border border-tertiary/30 rounded-xl text-sm text-secondary hover:bg-background transition-colors">

--- a/src/app/modules/admin-users/rendiciones-admin/rendiciones-admin.component.ts
+++ b/src/app/modules/admin-users/rendiciones-admin/rendiciones-admin.component.ts
@@ -9,6 +9,7 @@ import { InvoicesService } from '../../invoices/services/invoices.service';
 import { UserStateService } from '../../../services/user-state.service';
 import { NotificationService } from '../../../services/notification.service';
 import { AdvanceService } from '../../../services/advance.service';
+import { CategoriaService } from '../../../services/categoria.service';
 import { IExpenseReport } from '../../../interfaces/expense-report.interface';
 import { IAdvance, ADVANCE_STATUS_LABELS, ADVANCE_STATUS_COLORS } from '../../../interfaces/advance.interface';
 import { IUserResponse } from '../../../interfaces/user.interface';
@@ -87,10 +88,13 @@ export class RendicionesAdminComponent implements OnInit {
   private userStateService = inject(UserStateService);
   private notifications = inject(NotificationService);
   private advanceService = inject(AdvanceService);
+  private categoriaService = inject(CategoriaService);
   private fb = inject(FormBuilder);
 
   private allReports: IExpenseReport[] = [];
   private allOrphanedAdvances: IAdvance[] = [];
+  /** Nombre de categoría por id, para mostrar el detalle de líneas al aprobar. */
+  private categoryNameById = new Map<string, string>();
 
   filteredItems: UnifiedRendicionItem[] = [];
   users: IUserResponse[] = [];
@@ -155,6 +159,29 @@ export class RendicionesAdminComponent implements OnInit {
       next: (projects) => { this.projects = projects; },
       error: () => {},
     });
+
+    this.categoriaService.getAllFlat().subscribe({
+      next: (cats) => {
+        this.categoryNameById.clear();
+        for (const c of cats ?? []) this.categoryNameById.set(String(c._id), c.name);
+      },
+      error: () => {},
+    });
+  }
+
+  /** Líneas por categoría del viático en revisión (vacío si no es viático). */
+  approveViaticoLines(): any[] {
+    const item = this.pendingApproveItem();
+    if (!item || item.source !== 'report') return [];
+    const raw = item.raw as IExpenseReport;
+    return raw.type === 'viatico' ? ((raw as any).viaticoLines ?? []) : [];
+  }
+
+  /** Nombre de la categoría de una línea (acepta id suelto o ya poblado). */
+  viaticoCategoryName(line: any): string {
+    const c = line?.categoryId;
+    if (c && typeof c === 'object' && 'name' in c) return (c as { name: string }).name;
+    return this.categoryNameById.get(String(c)) || '—';
   }
 
   applyFilters(): void {

--- a/src/app/modules/mis-rendiciones/solicitud-viaticos/solicitud-viaticos.component.html
+++ b/src/app/modules/mis-rendiciones/solicitud-viaticos/solicitud-viaticos.component.html
@@ -178,6 +178,9 @@
             @if (form.get('projectId')?.invalid && form.get('projectId')?.touched) {
             <p class="text-xs text-red-500">Seleccione un centro de costo</p>
             }
+            @if (hasPendingBalance) {
+            <p class="text-xs text-gray-500">El centro de costo queda fijo por el saldo heredado; ese saldo solo puede usarse aquí.</p>
+            }
           </div>
 
           <!-- Saldo de la bolsa (mismo centro de costo) -->

--- a/src/app/modules/mis-rendiciones/solicitud-viaticos/solicitud-viaticos.component.ts
+++ b/src/app/modules/mis-rendiciones/solicitud-viaticos/solicitud-viaticos.component.ts
@@ -207,9 +207,34 @@ export class SolicitudViaticosComponent implements OnInit {
       if (fromReport && amount > 0) {
         this.pendingBalanceFromReportId.set(fromReport);
         this.pendingBalanceAmount.set(amount);
+        // El saldo heredado pertenece al centro de costo de la rendición de origen:
+        // se fija automáticamente y se bloquea (no puede trasladarse a otro).
+        this.lockProjectFromSourceReport(fromReport);
       }
       this.loadCatalogues();
     }
+  }
+
+  /**
+   * Fija y bloquea el centro de costo a partir de la rendición que origina el saldo
+   * heredado: ese saldo solo puede usarse en su mismo centro de costo, no en otro.
+   */
+  private lockProjectFromSourceReport(reportId: string): void {
+    this.expenseReportsService.findOne(reportId).subscribe({
+      next: (report) => {
+        const raw = report?.projectId as unknown;
+        const pid =
+          raw && typeof raw === 'object'
+            ? String((raw as { _id?: string })._id ?? '')
+            : String(raw ?? '');
+        if (!pid) return;
+        const ctrl = this.form.get('projectId');
+        ctrl?.setValue(pid);
+        this.selectedProjectId.set(pid);
+        ctrl?.disable({ emitEvent: false });
+      },
+      error: () => {},
+    });
   }
 
   /** Carga los saldos de viáticos elegibles (mismo centro de costo) y limpia la selección. */
@@ -553,6 +578,9 @@ export class SolicitudViaticosComponent implements OnInit {
     }
 
     const place = (this.form.value.place || '').trim();
+    // getRawValue: el centro de costo puede estar deshabilitado (saldo heredado),
+    // y los controles deshabilitados no aparecen en form.value.
+    const projectId = (this.form.getRawValue().projectId as string) ?? '';
     const linesPayload: IAdvanceLinePayload[] = [];
 
     for (let i = 0; i < this.lines.length; i++) {
@@ -592,7 +620,7 @@ export class SolicitudViaticosComponent implements OnInit {
         ...(this.selectedLng != null && { lng: this.selectedLng }),
         startDate: `${startStr}T12:00:00.000Z`,
         endDate: `${endStr}T12:00:00.000Z`,
-        projectId: this.form.value.projectId as string,
+        projectId,
         lines: linesPayload,
         observations: (this.form.value.observations || '').trim() || undefined,
         ...(this.canUseSaldoBag && saldoIds.length > 0 && { saldoIds }),
@@ -616,7 +644,7 @@ export class SolicitudViaticosComponent implements OnInit {
         ...(this.selectedLng != null && { lng: this.selectedLng }),
         startDate: `${startStr}T12:00:00.000Z`,
         endDate: `${endStr}T12:00:00.000Z`,
-        projectId: this.form.value.projectId as string,
+        projectId,
         lines: linesPayload,
         observations: (this.form.value.observations || '').trim() || undefined,
         ...(hasPending && {
@@ -640,7 +668,7 @@ export class SolicitudViaticosComponent implements OnInit {
       ...(this.selectedLng != null && { lng: this.selectedLng }),
       startDate: `${startStr}T12:00:00.000Z`,
       endDate: `${endStr}T12:00:00.000Z`,
-      projectId: this.form.value.projectId as string,
+      projectId,
       lines: linesPayload,
       observations: (this.form.value.observations || '').trim() || undefined,
       ...(hasPending && {

--- a/src/app/modules/tesoreria/tesoreria.component.html
+++ b/src/app/modules/tesoreria/tesoreria.component.html
@@ -301,7 +301,9 @@
     <div class="flex justify-center p-12">
       <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
     </div>
-    } @else if(filteredAdvances.length === 0 && (activeTab() !== 'pendientes' || pendingViaticoPayments.length === 0)) {
+    } @else if(filteredAdvances.length === 0
+      && (activeTab() !== 'pendientes' || pendingViaticoPayments.length === 0)
+      && (activeTab() !== 'aprobados' || paidViaticoPayments.length === 0)) {
     <div class="p-12 text-center text-tertiary text-sm">No hay registros en esta sección.</div>
     } @else {
 
@@ -345,6 +347,32 @@
                     class="text-xs px-3 py-1.5 bg-primary text-white rounded-lg hover:bg-primary/90 disabled:opacity-50 font-medium transition-colors">
                     {{ (rep.viaticoPaidAmount ?? 0) > 0 ? 'Pago parcial' : 'Registrar pago' }}
                   </button>
+                </div>
+              </td>
+            </tr>
+            }
+          }
+          @if (activeTab() === 'aprobados') {
+            @for (rep of paidViaticoPayments; track rep._id) {
+            <tr class="hover:bg-background/60 transition-colors">
+              <td class="px-5 py-3.5 font-medium text-secondary">{{ viaticoUserName(rep) }}</td>
+              <td class="px-5 py-3.5 text-tertiary max-w-[160px] truncate">{{ rep.viaticoPlace || rep.title || '—' }}</td>
+              <td class="px-5 py-3.5 text-right">
+                <span class="font-bold text-secondary">S/ {{ (rep.viaticoAmount ?? 0) | number:'1.2-2' }}</span>
+                <span class="block text-xs text-tertiary">Pagado: S/ {{ (rep.viaticoPaidAmount ?? 0) | number:'1.2-2' }}</span>
+              </td>
+              <td class="px-5 py-3.5 text-center">
+                <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium"
+                  [class]="viaticoRemaining(rep) > 0.009 ? 'bg-amber-100 text-amber-700' : 'bg-emerald-100 text-emerald-700'">
+                  {{ viaticoRemaining(rep) > 0.009 ? 'Pago parcial' : 'Pagado' }}
+                </span>
+              </td>
+              <td class="px-5 py-3.5 text-right">
+                <div class="flex items-center justify-end gap-2">
+                  <a [routerLink]="['/mis-rendiciones', rep._id, 'detalle']"
+                    class="text-xs px-3 py-1.5 border border-tertiary/30 text-secondary rounded-lg hover:bg-background transition-colors font-medium">
+                    Detalle
+                  </a>
                 </div>
               </td>
             </tr>
@@ -438,6 +466,32 @@
               class="flex-1 text-xs px-3 py-1.5 bg-primary text-white rounded-lg hover:bg-primary/90 disabled:opacity-50 font-medium transition-colors">
               {{ (rep.viaticoPaidAmount ?? 0) > 0 ? 'Pago parcial' : 'Registrar pago' }}
             </button>
+          </div>
+        </div>
+        }
+      }
+      @if (activeTab() === 'aprobados') {
+        @for (rep of paidViaticoPayments; track rep._id) {
+        <div class="p-4">
+          <div class="flex items-start justify-between gap-3 mb-3">
+            <div class="min-w-0">
+              <p class="text-sm font-semibold text-secondary truncate">{{ viaticoUserName(rep) }}</p>
+              <p class="text-xs text-tertiary mt-0.5 truncate">{{ rep.viaticoPlace || rep.title || '—' }}</p>
+            </div>
+            <div class="text-right shrink-0">
+              <p class="text-base font-bold text-secondary">S/ {{ (rep.viaticoAmount ?? 0) | number:'1.2-2' }}</p>
+              <p class="text-xs text-tertiary">Pagado: S/ {{ (rep.viaticoPaidAmount ?? 0) | number:'1.2-2' }}</p>
+              <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium mt-1"
+                [class]="viaticoRemaining(rep) > 0.009 ? 'bg-amber-100 text-amber-700' : 'bg-emerald-100 text-emerald-700'">
+                {{ viaticoRemaining(rep) > 0.009 ? 'Pago parcial' : 'Pagado' }}
+              </span>
+            </div>
+          </div>
+          <div class="flex gap-2">
+            <a [routerLink]="['/mis-rendiciones', rep._id, 'detalle']"
+              class="text-xs px-3 py-1.5 border border-tertiary/30 text-secondary rounded-lg hover:bg-background transition-colors font-medium">
+              Detalle
+            </a>
           </div>
         </div>
         }

--- a/src/app/modules/tesoreria/tesoreria.component.ts
+++ b/src/app/modules/tesoreria/tesoreria.component.ts
@@ -43,6 +43,8 @@ export class TesoreriaComponent implements OnInit {
   pendingReimbursements: IExpenseReport[] = [];
   /** Viáticos con status viatico_approved o partially_paid pendientes de pago. */
   pendingViaticoPayments: IExpenseReport[] = [];
+  /** Viáticos con al menos un pago de contabilidad registrado (pestaña "En pago"). */
+  paidViaticoPayments: IExpenseReport[] = [];
 
   selectedAdvance: IAdvance | null = null;
   selectedReportReimbursement: IExpenseReport | null = null;
@@ -222,15 +224,27 @@ export class TesoreriaComponent implements OnInit {
     const cid = this.clientId;
     if (!cid || !this.canPayAndSettle) {
       this.pendingViaticoPayments = [];
+      this.paidViaticoPayments = [];
       return;
     }
     this.expenseReportsService.findAllByClient(cid).subscribe({
       next: reports => {
-        this.pendingViaticoPayments = (reports ?? []).filter(
-          r => r.type === 'viatico' && ['viatico_approved', 'partially_paid'].includes(r.status)
+        const viaticos = (reports ?? []).filter(r => r.type === 'viatico');
+        // "Por pagar": aprobados o con pago parcial pendiente de completar.
+        this.pendingViaticoPayments = viaticos.filter(
+          r => ['viatico_approved', 'partially_paid'].includes(r.status)
+        );
+        // "En pago": tienen al menos un pago de contabilidad registrado. Se filtra
+        // por viaticoPayments (no por estado/viaticoPaidAmount) para excluir los
+        // cubiertos 100% con saldo, que se abren sin pago de contabilidad.
+        this.paidViaticoPayments = viaticos.filter(
+          r => Array.isArray(r.viaticoPayments) && r.viaticoPayments.length > 0
         );
       },
-      error: () => { this.pendingViaticoPayments = []; },
+      error: () => {
+        this.pendingViaticoPayments = [];
+        this.paidViaticoPayments = [];
+      },
     });
   }
 


### PR DESCRIPTION
… tesoreria, lock de centro de costo por saldo heredado

- rendiciones-admin: el modal de aprobacion del coordinador ahora muestra el detalle por categoria (categoria/importe/personas/dias/total) antes de confirmar.
- tesoreria: los viaticos con pago de contabilidad registrado aparecen en la pestana "En pago" con estado Pagado/Pago parcial (antes desaparecian al pagar). Se filtra por viaticoPayments para excluir los cubiertos 100% con saldo.
- solicitud-viaticos: con saldo heredado (pendingBalanceFromReportId), el centro de costo se autoselecciona desde la rendicion de origen y se bloquea; el saldo solo puede usarse en ese mismo centro de costo. submit usa getRawValue.