### PR TITLE
feat(inicio): dashboard role-aware con secciones de viáticos y rendic…

### DIFF
--- a/src/app/modules/inicio/inicio.component.html
+++ b/src/app/modules/inicio/inicio.component.html
@@ -3,7 +3,7 @@
   <!-- ── Greeting ──────────────────────────────────────────────── -->
   <div class="mb-7">
     <h1 class="text-2xl font-bold text-secondary">{{ greeting }}, {{ userName }} 👋</h1>
-    <p class="text-sm text-tertiary mt-1">Aquí tienes un resumen de tu actividad.</p>
+    <p class="text-sm text-tertiary mt-1">{{ subtitle }}</p>
   </div>
 
   @if (isLoading()) {
@@ -12,79 +12,228 @@
   </div>
   } @else {
 
-  <!-- ── KPI Cards: pendientes ──────────────────────────────────── -->
-  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
+  <!-- ════════════════════════════════════════════════════════════ -->
+  <!--  COORDINADOR                                                  -->
+  <!-- ════════════════════════════════════════════════════════════ -->
+  @if (isCoordinador) {
 
-    <!-- Solicitudes de viáticos pendientes (primero) -->
-    <a
-      routerLink="/mis-rendiciones"
-      [queryParams]="{ tab: 'viaticos' }"
-      class="bg-quaternary rounded-2xl border border-tertiary/20 p-5 flex flex-col gap-3 hover:border-primary/40 hover:bg-primary/5 transition-all"
-    >
+  <!-- ── Sección: Aprobaciones de mi equipo ───────────────────────── -->
+  <h2 class="text-sm font-bold text-secondary uppercase tracking-wider mb-3">Aprobaciones de mi equipo</h2>
+
+  <!-- KPI Cards -->
+  <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+
+    <!-- Solicitudes por aprobar (PRIMERO) -->
+    <a routerLink="/rendiciones"
+      class="bg-quaternary rounded-2xl border border-tertiary/20 p-5 flex flex-col gap-3 hover:border-primary/40 hover:bg-primary/5 transition-all">
       <div class="flex items-center justify-between">
-        <span class="text-xs font-semibold text-tertiary uppercase tracking-wider">Solicitudes de viáticos</span>
+        <span class="text-xs font-semibold text-tertiary uppercase tracking-wider">Solicitudes por aprobar</span>
         <div class="w-8 h-8 rounded-xl flex items-center justify-center"
-          [class]="kpiAnticiposPendientes() > 0 ? 'bg-yellow-100' : 'bg-gray-100'">
+          [class]="kpiSolicitudesPendientes() > 0 ? 'bg-red-100' : 'bg-gray-100'">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
-            class="w-4 h-4" [class]="kpiAnticiposPendientes() > 0 ? 'text-yellow-600' : 'text-tertiary'">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18.75a60.07 60.07 0 0 1 15.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 0 1 3 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 0 0-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 0 1-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 0 0 3 15h-.75M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm3 0h.008v.008H18V10.5Zm-12 0h.008v.008H6V10.5Z" />
+            class="w-4 h-4" [class]="kpiSolicitudesPendientes() > 0 ? 'text-red-600' : 'text-tertiary'">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
           </svg>
         </div>
       </div>
-      <p class="text-3xl font-bold text-secondary">{{ kpiAnticiposPendientes() }}</p>
+      <p class="text-3xl font-bold text-secondary">{{ kpiSolicitudesPendientes() }}</p>
       <p class="text-xs text-tertiary">
-        @if (kpiAnticiposPendientes() > 0) { pendiente{{ kpiAnticiposPendientes() !== 1 ? 's' : '' }} de aprobación }
-        @else { sin pendientes }
+        @if (kpiSolicitudesPendientes() > 0) { solicitud{{ kpiSolicitudesPendientes() !== 1 ? 'es' : '' }} de viáticos por aprobar }
+        @else { sin solicitudes pendientes }
       </p>
     </a>
 
-    <!-- Rendiciones directas pendientes -->
-    <a
-      routerLink="/mis-rendiciones"
-      [queryParams]="{ tab: 'directas' }"
-      class="bg-quaternary rounded-2xl border border-tertiary/20 p-5 flex flex-col gap-3 hover:border-primary/40 hover:bg-primary/5 transition-all"
-    >
+    <!-- Rendiciones por aprobar -->
+    <a routerLink="/rendiciones"
+      class="bg-quaternary rounded-2xl border border-tertiary/20 p-5 flex flex-col gap-3 hover:border-primary/40 hover:bg-primary/5 transition-all">
       <div class="flex items-center justify-between">
-        <span class="text-xs font-semibold text-tertiary uppercase tracking-wider">Rendiciones directas</span>
+        <span class="text-xs font-semibold text-tertiary uppercase tracking-wider">Rendiciones por aprobar</span>
         <div class="w-8 h-8 rounded-xl flex items-center justify-center"
-          [class]="kpiDirectasPendientes() > 0 ? 'bg-blue-100' : 'bg-gray-100'">
+          [class]="kpiRendicionesPorAprobar() > 0 ? 'bg-blue-100' : 'bg-gray-100'">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
-            class="w-4 h-4" [class]="kpiDirectasPendientes() > 0 ? 'text-blue-600' : 'text-tertiary'">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+            class="w-4 h-4" [class]="kpiRendicionesPorAprobar() > 0 ? 'text-blue-600' : 'text-tertiary'">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
           </svg>
         </div>
       </div>
-      <p class="text-3xl font-bold text-secondary">{{ kpiDirectasPendientes() }}</p>
+      <p class="text-3xl font-bold text-secondary">{{ kpiRendicionesPorAprobar() }}</p>
       <p class="text-xs text-tertiary">
-        @if (kpiDirectasPendientes() > 0) { pendiente{{ kpiDirectasPendientes() !== 1 ? 's' : '' }} }
-        @else { sin pendientes }
-      </p>
-    </a>
-
-    <!-- Bolsa total disponible -->
-    <a
-      routerLink="/saldo"
-      class="bg-quaternary rounded-2xl border border-tertiary/20 p-5 flex flex-col gap-3 hover:border-primary/40 hover:bg-primary/5 transition-all"
-    >
-      <div class="flex items-center justify-between">
-        <span class="text-xs font-semibold text-tertiary uppercase tracking-wider">Bolsa total disponible</span>
-        <div class="w-8 h-8 rounded-xl flex items-center justify-center"
-          [class]="saldoService.total() > 0 ? 'bg-primary/10' : 'bg-gray-100'">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
-            class="w-4 h-4" [class]="saldoService.total() > 0 ? 'text-primary' : 'text-tertiary'">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
-          </svg>
-        </div>
-      </div>
-      <p class="text-3xl font-bold text-secondary">S/. {{ saldoService.total() | number:'1.2-2' }}</p>
-      <p class="text-xs text-tertiary">
-        @if (saldoService.total() > 0) { disponible para usar }
-        @else { sin saldo disponible }
+        @if (kpiRendicionesPorAprobar() > 0) { rendición{{ kpiRendicionesPorAprobar() !== 1 ? 'es' : '' }} esperando revisión }
+        @else { sin rendiciones por aprobar }
       </p>
     </a>
 
   </div>
 
+  <!-- Listados -->
+  <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+    <ng-container *ngTemplateOutlet="listCard; context: {
+      title: 'Solicitudes por aprobar',
+      rows: visibleSolicitudes(),
+      total: solicitudesRows().length,
+      showAllSig: showAllAprobaciones,
+      empty: 'No hay solicitudes de viáticos por aprobar.',
+      showUser: true,
+      approveKind: 'solicitud'
+    }"></ng-container>
+
+    <ng-container *ngTemplateOutlet="listCard; context: {
+      title: 'Rendiciones por aprobar',
+      rows: visibleRendicionesAprob(),
+      total: rendicionesRows().length,
+      showAllSig: showAllPersonal,
+      empty: 'No hay rendiciones de viáticos por aprobar.',
+      showUser: true,
+      approveKind: 'rendicion'
+    }"></ng-container>
+  </div>
+
+  <!-- ── Sección: Mi actividad (rendiciones propias del coordinador) ── -->
+  <h2 class="text-sm font-bold text-secondary uppercase tracking-wider mt-9 mb-3">Mi actividad</h2>
+  <ng-container *ngTemplateOutlet="miActividad"></ng-container>
+
+  }
+  <!-- ════════════════════════════════════════════════════════════ -->
+  <!--  COLABORADOR                                                  -->
+  <!-- ════════════════════════════════════════════════════════════ -->
+  @else {
+
+  <ng-container *ngTemplateOutlet="miActividad"></ng-container>
+
+  }
+
   } <!-- end @else isLoading -->
 
 </div>
+
+<!-- ── Plantilla reutilizable de listado (5 + expandir) ──────────── -->
+<ng-template #listCard let-title="title" let-rows="rows" let-total="total" let-showAllSig="showAllSig"
+  let-empty="empty" let-showUser="showUser" let-approveKind="approveKind">
+  <div class="bg-quaternary rounded-2xl border border-tertiary/20 overflow-hidden">
+    <div class="px-5 py-4 border-b border-tertiary/10 flex items-center justify-between">
+      <h2 class="text-sm font-semibold text-secondary">{{ title }}</h2>
+      <span class="text-xs text-tertiary">{{ total }}</span>
+    </div>
+
+    @if (rows.length === 0) {
+    <p class="px-5 py-10 text-center text-sm text-tertiary">{{ empty }}</p>
+    } @else {
+    <ul class="divide-y divide-tertiary/10">
+      @for (row of rows; track row._id) {
+      <li (click)="goToRow(row)"
+        class="px-5 py-3 flex items-center gap-3 hover:bg-primary/5 cursor-pointer transition-colors">
+        <div class="min-w-0 flex-1">
+          <p class="text-sm font-medium text-secondary truncate">{{ row.title }}</p>
+          <p class="text-xs text-tertiary truncate">
+            @if (showUser) {<span class="font-medium text-secondary/70">{{ row.userName }}</span> · }@if (row.project) {{{ row.project }} · }{{ row.createdAt | date:'dd/MM/yyyy' }}
+          </p>
+        </div>
+        <span class="text-sm font-semibold text-secondary whitespace-nowrap">S/. {{ row.amount | number:'1.2-2' }}</span>
+        <span class="text-[11px] font-medium px-2 py-0.5 rounded-full whitespace-nowrap" [class]="row.statusColor">{{ row.statusLabel }}</span>
+        @if (approveKind && canApproveRow(row, approveKind)) {
+        <button (click)="approveRow(row, approveKind, $event)" [disabled]="acting() === row._id"
+          class="text-[11px] font-semibold px-2.5 py-1 rounded-lg bg-green-600 text-white hover:bg-green-700 disabled:opacity-50 whitespace-nowrap transition-colors">
+          {{ acting() === row._id ? '...' : (approveKind === 'rendicion' ? 'Aprobar rendición' : 'Aprobar') }}
+        </button>
+        }
+      </li>
+      }
+    </ul>
+
+    @if (total > PREVIEW) {
+    <button (click)="showAllSig.set(!showAllSig())"
+      class="w-full px-5 py-3 text-xs font-semibold text-primary hover:bg-primary/5 transition-colors border-t border-tertiary/10">
+      {{ showAllSig() ? 'Ver menos' : 'Expandir (' + (total - PREVIEW) + ' más)' }}
+    </button>
+    }
+    }
+  </div>
+</ng-template>
+
+<!-- ── Tarjeta KPI reutilizable ──────────────────────────────────── -->
+<ng-template #kpiCard let-title="title" let-value="value" let-hint="hint" let-link="link"
+  let-qp="qp" let-accent="accent" let-money="money">
+  <a [routerLink]="link" [queryParams]="qp || {}"
+    class="bg-quaternary rounded-2xl border border-tertiary/20 p-5 flex flex-col gap-3 hover:border-primary/40 hover:bg-primary/5 transition-all">
+    <div class="flex items-center justify-between">
+      <span class="text-xs font-semibold text-tertiary uppercase tracking-wider">{{ title }}</span>
+      <div class="w-8 h-8 rounded-xl flex items-center justify-center" [class]="iconBg(accent, value > 0)">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+          stroke="currentColor" class="w-4 h-4" [class]="iconText(accent, value > 0)">
+          @if (money) {
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+          } @else {
+          <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+          }
+        </svg>
+      </div>
+    </div>
+    <p class="text-3xl font-bold text-secondary">@if (money) {S/. {{ value | number:'1.2-2' }}} @else {{{ value }}}</p>
+    <p class="text-xs text-tertiary">{{ hint }}</p>
+  </a>
+</ng-template>
+
+<!-- ── "Mi actividad" reutilizable (colaborador + coordinador) ───── -->
+<!-- Separa VIÁTICOS (solicitudes + rendiciones) de RENDICIONES DIRECTAS. -->
+<ng-template #miActividad>
+  <!-- Bolsa (siempre) -->
+  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-2">
+    <ng-container *ngTemplateOutlet="kpiCard; context: {
+      title: 'Bolsa total disponible', value: saldoService.total(), money: true, accent: 'primary',
+      link: '/saldo', hint: saldoService.total() > 0 ? 'disponible para usar' : 'sin saldo disponible'
+    }"></ng-container>
+  </div>
+
+  <!-- VIÁTICOS -->
+  @if (canSeeViaticos) {
+  <h3 class="text-xs font-bold text-tertiary uppercase tracking-wider mt-6 mb-3">Viáticos</h3>
+  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+    <ng-container *ngTemplateOutlet="kpiCard; context: {
+      title: 'Solicitudes de viáticos', value: kpiSolicitudesViaticos(), accent: 'yellow',
+      link: '/mis-rendiciones', qp: { tab: 'viaticos' }, hint: 'pendientes de aprobación'
+    }"></ng-container>
+    <ng-container *ngTemplateOutlet="kpiCard; context: {
+      title: 'Rendiciones de viáticos', value: kpiRendicionesViaticos(), accent: 'blue',
+      link: '/mis-rendiciones', qp: { tab: 'viaticos' }, hint: 'por rendir / cerrar'
+    }"></ng-container>
+    <ng-container *ngTemplateOutlet="kpiCard; context: {
+      title: 'Por enviar a revisión', value: kpiPendientesViaticos(), accent: 'red',
+      link: '/mis-rendiciones', qp: { tab: 'viaticos' }, hint: 'con gastos por subir o enviar'
+    }"></ng-container>
+  </div>
+  <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-4">
+    <ng-container *ngTemplateOutlet="listCard; context: {
+      title: 'Mis solicitudes de viáticos', rows: visibleSolViaticos(),
+      total: misSolicitudesViaticosRows().length, showAllSig: showAllViaticos,
+      empty: 'No tienes solicitudes de viáticos.', showUser: false
+    }"></ng-container>
+    <ng-container *ngTemplateOutlet="listCard; context: {
+      title: 'Mis rendiciones de viáticos', rows: visibleRendViaticos(),
+      total: misRendicionesViaticosRows().length, showAllSig: showAllRendiciones,
+      empty: 'No tienes rendiciones de viáticos.', showUser: false
+    }"></ng-container>
+  </div>
+  }
+
+  <!-- RENDICIONES DIRECTAS -->
+  @if (canSeeRendiciones) {
+  <h3 class="text-xs font-bold text-tertiary uppercase tracking-wider mt-6 mb-3">Rendiciones directas</h3>
+  <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+    <ng-container *ngTemplateOutlet="kpiCard; context: {
+      title: 'Rendiciones directas', value: kpiDirectasSinCerrar(), accent: 'purple',
+      link: '/mis-rendiciones', qp: { tab: 'directas' }, hint: 'sin cerrar'
+    }"></ng-container>
+    <ng-container *ngTemplateOutlet="kpiCard; context: {
+      title: 'Por enviar a revisión', value: kpiPendientesDirectas(), accent: 'red',
+      link: '/mis-rendiciones', qp: { tab: 'directas' }, hint: 'con gastos por subir o enviar'
+    }"></ng-container>
+  </div>
+  <div class="grid grid-cols-1 gap-4 mt-4">
+    <ng-container *ngTemplateOutlet="listCard; context: {
+      title: 'Mis rendiciones directas', rows: visibleDirectasPropias(),
+      total: misDirectasRows().length, showAllSig: showAllDirectas,
+      empty: 'No tienes rendiciones directas.', showUser: false
+    }"></ng-container>
+  </div>
+  }
+</ng-template>

--- a/src/app/modules/inicio/inicio.component.ts
+++ b/src/app/modules/inicio/inicio.component.ts
@@ -1,13 +1,29 @@
 import { Component, inject, OnInit, computed, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router, RouterModule } from '@angular/router';
-import { forkJoin } from 'rxjs';
+import { forkJoin, of, Observable } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 import { UserStateService } from '../../services/user-state.service';
 import { ExpenseReportsService } from '../../services/expense-reports.service';
 import { AdvanceService } from '../../services/advance.service';
 import { SaldoService } from '../../services/saldo.service';
+import { NotificationService } from '../../services/notification.service';
 import { IExpenseReport } from '../../interfaces/expense-report.interface';
 import { IAdvance, ADVANCE_STATUS_LABELS, ADVANCE_STATUS_COLORS } from '../../interfaces/advance.interface';
+
+/** Fila normalizada que alimenta los listados del inicio (colaborador y coordinador). */
+export interface DashRow {
+  _id: string;
+  source: 'report' | 'advance';
+  title: string;
+  userName: string;
+  project: string;
+  amount: number;
+  status: string;
+  statusLabel: string;
+  statusColor: string;
+  createdAt: string;
+}
 
 @Component({
   selector: 'app-inicio',
@@ -19,26 +35,70 @@ export class InicioComponent implements OnInit {
   private userState = inject(UserStateService);
   private expenseReportsService = inject(ExpenseReportsService);
   private advanceService = inject(AdvanceService);
+  private notifications = inject(NotificationService);
   saldoService = inject(SaldoService);
   private router = inject(Router);
 
   isLoading = signal(true);
-  reports = signal<IExpenseReport[]>([]);
-  advances = signal<IAdvance[]>([]);
+  /** _id de la fila que se está aprobando (deshabilita su botón). */
+  acting = signal<string | null>(null);
+
+  // Colaborador: datos propios
+  reports = signal<IExpenseReport[]>([]);        // rendiciones directas/normales
+  viaticoReports = signal<IExpenseReport[]>([]); // solicitudes de viáticos (modelo nuevo)
+  advances = signal<IAdvance[]>([]);             // solicitudes de viáticos (modelo legacy)
+
+  // Coordinador: datos del equipo (scope por personal lo aplica el backend)
+  teamReports = signal<IExpenseReport[]>([]);
+  teamAdvances = signal<IAdvance[]>([]); // solicitudes de viáticos legacy del equipo (orphaned)
+
+  // Toggles "ver más / expandir" por listado
+  showAllViaticos = signal(false);       // Mi actividad: mis solicitudes de viáticos
+  showAllRendiciones = signal(false);    // Mi actividad: mis rendiciones de viáticos
+  showAllDirectas = signal(false);       // Mi actividad: mis rendiciones directas
+  showAllAprobaciones = signal(false);   // Equipo: solicitudes por aprobar
+  showAllPersonal = signal(false);       // Equipo: rendiciones por aprobar
+
+  readonly PREVIEW = 5;
+
+  readonly isCoordinador = this.userState.isCoordinador();
+  readonly canApproveL1 = this.userState.canApproveL1();
+  readonly canApproveL2 = this.userState.canApproveL2();
+
+  // Permisos → controlan qué tarjetas/listas propias se muestran (tanto coordinador
+  // como colaborador se rigen por lo que tengan ACTIVADO). Modelo del negocio:
+  //   • Viáticos (solicitudes + rendiciones de viáticos) → módulo 'mis-rendiciones'
+  //   • Rendiciones directas                            → módulo 'nueva-rendicion'
+  // OJO: el módulo 'viaticos' es para gestión/aprobación, NO para tener viáticos
+  // propios — por eso NO se usa aquí. Getters para reflejar permisos vigentes tras
+  // refreshPermissions(). hasModulePermission ya devuelve true para admin/contab.
+  get canSeeViaticos(): boolean {
+    return this.userState.hasModulePermission('mis-rendiciones');
+  }
+  get canSeeRendiciones(): boolean {
+    return this.userState.canCreateRendicion();
+  }
 
   readonly STATUS_LABELS = ADVANCE_STATUS_LABELS;
   readonly STATUS_COLORS = ADVANCE_STATUS_COLORS;
 
   readonly REPORT_STATUS_LABELS: Record<string, string> = {
     solicited: 'Solicitada',
-    open: 'Abierta',
+    open: 'Registrando gastos',
     submitted: 'Enviada',
-    pending_accounting: 'Pendiente contabilidad',
+    pending_accounting: 'En contabilidad',
     approved: 'Aprobada',
     rejected: 'Rechazada',
-    reimbursed: 'Reembolsado',
+    reimbursed: 'Reembolsada',
     closed: 'Cerrada',
     cancelled: 'Cancelada',
+    // fases de viático (cuando el viático se modela como reporte)
+    pending_l1: 'En solicitud',
+    pending_l2: 'Aprobada por coordinador',
+    viatico_approved: 'Aprobada',
+    partially_paid: 'Pago parcial',
+    settled: 'Liquidada',
+    returned: 'Saldo devuelto',
   };
 
   readonly REPORT_STATUS_COLORS: Record<string, string> = {
@@ -51,76 +111,17 @@ export class InicioComponent implements OnInit {
     reimbursed: 'bg-teal-100 text-teal-700',
     closed: 'bg-gray-100 text-gray-600',
     cancelled: 'bg-orange-100 text-orange-700',
+    pending_l1: 'bg-yellow-100 text-yellow-700',
+    pending_l2: 'bg-orange-100 text-orange-700',
+    viatico_approved: 'bg-blue-100 text-blue-700',
+    partially_paid: 'bg-amber-100 text-amber-700',
+    settled: 'bg-emerald-100 text-emerald-700',
   };
 
-  // ── KPIs ─────────────────────────────────────────────────────────
-  kpiRendicionesActivas = computed(() =>
-    this.reports().filter((r) => r.status === 'open' || r.status === 'submitted').length
-  );
+  /** Estados que NO cuentan como "sin cerrar" (rendición finalizada). */
+  private readonly CLOSED_STATUSES = ['closed', 'cancelled', 'rejected', 'reimbursed'];
 
-  kpiPresupuestoTotal = computed(() =>
-    this.reports().reduce((sum, r) => sum + (r.budget || 0), 0)
-  );
-
-  kpiGastado = computed(() =>
-    this.reports().reduce((sum, r) => {
-      const total = r.expenseIds?.reduce((s: number, e: any) => s + (e.total || 0), 0) || 0;
-      return sum + total;
-    }, 0)
-  );
-
-  kpiComprobantes = computed(() =>
-    this.reports().reduce((sum, r) => sum + (r.expenseIds?.length || 0), 0)
-  );
-
-  kpiAnticiposPendientes = computed(() =>
-    this.advances().filter((a) => a.status === 'pending_l1' || a.status === 'pending_l2').length
-  );
-
-  /**
-   * Rendiciones directas del colaborador que siguen en curso (pendientes de
-   * resolución). Estados activos: en preparación, registrando gastos, enviada
-   * o en contabilidad. Las finalizadas (aprobada/cerrada/rechazada/etc.) no cuentan.
-   */
-  kpiDirectasPendientes = computed(() =>
-    this.reports().filter(
-      (r) =>
-        (r.isDirecta || r.type === 'directa') &&
-        ['solicited', 'open', 'submitted', 'pending_accounting'].includes(r.status)
-    ).length
-  );
-
-  paidAdvances = computed(() =>
-    this.advances()
-      .filter((a) => a.status === 'paid' || a.status === 'partially_paid')
-      .filter((a) => {
-        const reportId = this.getAdvanceReportId(a);
-        if (!reportId) return true;
-        const report = this.reports().find((r) => r._id === reportId);
-        return !report || report.status === 'open';
-      })
-  );
-
-  kpiAnticiposMonto = computed(() =>
-    this.advances()
-      .filter((a) => ['approved', 'partially_paid', 'paid', 'settled'].includes(a.status))
-      .reduce((sum, a) => sum + (a.status === 'approved' ? 0 : Number(a.paidAmount ?? a.amount) || 0), 0)
-  );
-
-  // ── Recientes ────────────────────────────────────────────────────
-  recentReports = computed(() =>
-    [...this.reports()]
-      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
-      .slice(0, 3)
-  );
-
-  recentAdvances = computed(() =>
-    [...this.advances()]
-      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
-      .slice(0, 3)
-  );
-
-  // ── Greeting ─────────────────────────────────────────────────────
+  // ─── Greeting ─────────────────────────────────────────────────────
   get greeting(): string {
     const h = new Date().getHours();
     if (h < 12) return 'Buenos días';
@@ -132,9 +133,131 @@ export class InicioComponent implements OnInit {
     return this.userState.getUser()?.name?.split(' ')[0] || 'colaborador';
   }
 
+  get subtitle(): string {
+    return this.isCoordinador
+      ? 'Aquí tienes lo pendiente de tu equipo.'
+      : 'Aquí tienes un resumen de tu actividad.';
+  }
+
+  // ════════════════════════════════════════════════════════════════
+  //  COLABORADOR / MI ACTIVIDAD — separado en VIÁTICOS vs RENDICIONES DIRECTAS
+  // ════════════════════════════════════════════════════════════════
+
+  private isDirecta(r: IExpenseReport): boolean {
+    return r.isDirecta === true || r.type === 'directa';
+  }
+
+  /**
+   * VIÁTICOS — Solicitudes: viáticos a la espera de aprobación (pending_l1/l2).
+   * Modelo nuevo (reports type=viatico) + legacy (advances).
+   */
+  misSolicitudesViaticosRows = computed<DashRow[]>(() => {
+    const fromReports = this.viaticoReports()
+      .filter((r) => this.isPendingApproval(r.status))
+      .map((r) => this.reportRow(r));
+    const fromAdvances = this.advances()
+      .filter((a) => this.isPendingApproval(a.status))
+      .map((a) => this.advanceRow(a));
+    return [...fromReports, ...fromAdvances].sort((a, b) => this.ts(b.createdAt) - this.ts(a.createdAt));
+  });
+
+  /**
+   * VIÁTICOS — Rendiciones: viáticos ya aprobados que se están rindiendo (sin cerrar).
+   * Modelo nuevo (type=viatico ya no pendiente) + legacy ("Viático: …", reports no
+   * directos y no type viatico).
+   */
+  misRendicionesViaticosRows = computed<DashRow[]>(() => {
+    const fromViatico = this.viaticoReports()
+      .filter((r) => !this.isPendingApproval(r.status) && !this.CLOSED_STATUSES.includes(r.status))
+      .map((r) => this.reportRow(r));
+    const legacy = this.reports()
+      .filter((r) => !this.isDirecta(r) && r.type !== 'viatico' && !this.CLOSED_STATUSES.includes(r.status))
+      .map((r) => this.reportRow(r));
+    return [...fromViatico, ...legacy].sort((a, b) => this.ts(b.createdAt) - this.ts(a.createdAt));
+  });
+
+  /** RENDICIONES DIRECTAS — propias del colaborador, sin cerrar (isDirecta). */
+  misDirectasRows = computed<DashRow[]>(() =>
+    this.reports()
+      .filter((r) => this.isDirecta(r) && !this.CLOSED_STATUSES.includes(r.status))
+      .sort((a, b) => this.ts(b.createdAt) - this.ts(a.createdAt))
+      .map((r) => this.reportRow(r))
+  );
+
+  kpiSolicitudesViaticos = computed(() => this.misSolicitudesViaticosRows().length);
+  kpiRendicionesViaticos = computed(() => this.misRendicionesViaticosRows().length);
+  kpiDirectasSinCerrar = computed(() => this.misDirectasRows().length);
+
+  /**
+   * PENDIENTES DE ACCIÓN del colaborador: rendiciones donde debe subir gastos o
+   * enviarlas a revisión. Estados: 'open'/'solicited' (registrando gastos) y
+   * 'rejected' (corregir y reenviar). Se cuentan POR SECCIÓN (viáticos / directas).
+   */
+  private readonly ACTION_NEEDED = ['open', 'solicited', 'rejected'];
+  private isActionNeeded = (r: DashRow) => this.ACTION_NEEDED.includes(r.status);
+
+  /** Rendiciones de viáticos que el colaborador debe subir/enviar. */
+  kpiPendientesViaticos = computed(() => this.misRendicionesViaticosRows().filter(this.isActionNeeded).length);
+  /** Rendiciones directas que el colaborador debe subir/enviar. */
+  kpiPendientesDirectas = computed(() => this.misDirectasRows().filter(this.isActionNeeded).length);
+
+  // ════════════════════════════════════════════════════════════════
+  //  COORDINADOR
+  // ════════════════════════════════════════════════════════════════
+
+  /**
+   * Solicitudes por aprobar (equipo): el colaborador recién envió la solicitud de
+   * viáticos y espera la firma del coordinador (pending_l1 / pending_l2). Incluye el
+   * modelo nuevo (reports type=viatico) y el legacy (advances orphaned), igual que /rendiciones.
+   */
+  solicitudesRows = computed<DashRow[]>(() => {
+    const fromReports = this.teamReports()
+      .filter((r) => r.type === 'viatico' && this.isPendingApproval(r.status))
+      .map((r) => this.reportRow(r));
+    const fromAdvances = this.teamAdvances()
+      .filter((a) => this.isPendingApproval(a.status))
+      .map((a) => this.advanceRow(a));
+    return [...fromReports, ...fromAdvances].sort((a, b) => this.ts(b.createdAt) - this.ts(a.createdAt));
+  });
+
+  kpiSolicitudesPendientes = computed(() => this.solicitudesRows().length);
+
+  /**
+   * Rendiciones por aprobar (equipo): 2ª etapa de la solicitud de viáticos. El viático
+   * ya fue aprobado y pagado; el colaborador rindió sus gastos y el reporte espera la
+   * aprobación del coordinador. SOLO estado 'submitted' (Enviada): cuando pasa a
+   * 'pending_accounting' (En contabilidad) ya salió del coordinador → no se lista ni
+   * cuenta aquí. Son viáticos en su fase de rendición — las directas NO van aquí.
+   */
+  rendicionesRows = computed<DashRow[]>(() =>
+    this.teamReports()
+      .filter((r) => r.type === 'viatico' && r.status === 'submitted')
+      .sort((a, b) => this.ts(b.createdAt) - this.ts(a.createdAt))
+      .map((r) => this.reportRow(r))
+  );
+
+  kpiRendicionesPorAprobar = computed(() => this.rendicionesRows().length);
+
+  // ─── Slices visibles (preview 5 + expandir) ───────────────────────
+  // Mi actividad (propias) — Viáticos
+  visibleSolViaticos = computed(() => this.slice(this.misSolicitudesViaticosRows(), this.showAllViaticos()));
+  visibleRendViaticos = computed(() => this.slice(this.misRendicionesViaticosRows(), this.showAllRendiciones()));
+  // Mi actividad (propias) — Rendiciones directas
+  visibleDirectasPropias = computed(() => this.slice(this.misDirectasRows(), this.showAllDirectas()));
+  // Aprobación de mi equipo
+  visibleSolicitudes = computed(() => this.slice(this.solicitudesRows(), this.showAllAprobaciones()));
+  visibleRendicionesAprob = computed(() => this.slice(this.rendicionesRows(), this.showAllPersonal()));
+
+  private slice(rows: DashRow[], showAll: boolean): DashRow[] {
+    return showAll ? rows : rows.slice(0, this.PREVIEW);
+  }
+
+  // ─── Carga ────────────────────────────────────────────────────────
   ngOnInit() {
-    // Bolsa total disponible (usa el token del usuario autenticado).
     this.saldoService.refreshTotal();
+    // Trae los permisos vigentes del servidor (los de localStorage pueden estar
+    // desactualizados si se cambiaron en otra sesión) para gatear bien las tarjetas.
+    this.userState.refreshPermissions().subscribe();
 
     const user = this.userState.getUser() as any;
     const userId = user?._id;
@@ -145,12 +268,22 @@ export class InicioComponent implements OnInit {
       return;
     }
 
+    if (this.isCoordinador) {
+      this.loadCoordinador(clientId);
+    } else {
+      this.loadColaborador(userId, clientId);
+    }
+  }
+
+  private loadColaborador(userId: string, clientId: string) {
     forkJoin({
-      reports: this.expenseReportsService.findAllByUser(userId, clientId),
-      advances: this.advanceService.findMy(),
+      reports: this.expenseReportsService.findAllByUser(userId, clientId).pipe(catchError(() => of([]))),
+      viaticos: this.expenseReportsService.getMyViaticos().pipe(catchError(() => of([]))),
+      advances: this.advanceService.findMy().pipe(catchError(() => of([]))),
     }).subscribe({
-      next: ({ reports, advances }) => {
+      next: ({ reports, viaticos, advances }) => {
         this.reports.set(reports);
+        this.viaticoReports.set(viaticos);
         this.advances.set(advances);
         this.isLoading.set(false);
       },
@@ -158,49 +291,168 @@ export class InicioComponent implements OnInit {
     });
   }
 
-  goToRendicion(id: string) {
-    this.router.navigate(['/mis-rendiciones', id, 'detalle']);
+  /**
+   * Coordinador = aprobador de su equipo + usuario que también rinde. Cargamos:
+   * - teamReports: `expense-report/client/:clientId` → el backend aplica
+   *   `findAllByCoordinator` (solo su personal) para las colas de aprobación.
+   * - reports/viaticoReports/advances: SUS PROPIAS rendiciones y solicitudes
+   *   (igual que un colaborador), para la sección "Mi actividad" (/mis-rendiciones).
+   */
+  private loadCoordinador(clientId: string) {
+    const userId = (this.userState.getUser() as any)?._id;
+    forkJoin({
+      team: this.expenseReportsService.findAllByClient(clientId).pipe(catchError(() => of([]))),
+      teamAdvances: this.advanceService.findOrphaned(clientId).pipe(catchError(() => of([]))),
+      ownReports: this.expenseReportsService.findAllByUser(userId, clientId).pipe(catchError(() => of([]))),
+      ownViaticos: this.expenseReportsService.getMyViaticos().pipe(catchError(() => of([]))),
+      ownAdvances: this.advanceService.findMy().pipe(catchError(() => of([]))),
+    }).subscribe({
+      next: ({ team, teamAdvances, ownReports, ownViaticos, ownAdvances }) => {
+        this.teamReports.set(team);
+        this.teamAdvances.set(teamAdvances);
+        this.reports.set(ownReports);
+        this.viaticoReports.set(ownViaticos);
+        this.advances.set(ownAdvances);
+        this.isLoading.set(false);
+      },
+      error: () => this.isLoading.set(false),
+    });
   }
 
-  getReportStatusLabel(status: string): string {
-    return this.REPORT_STATUS_LABELS[status] || status;
+  /** Recarga solo las colas de aprobación del equipo (tras aprobar una fila). */
+  private reloadCoordinador() {
+    const user = this.userState.getUser() as any;
+    const clientId = user?.companyId || user?.clientId;
+    if (!clientId) return;
+    forkJoin({
+      team: this.expenseReportsService.findAllByClient(clientId).pipe(catchError(() => of([]))),
+      teamAdvances: this.advanceService.findOrphaned(clientId).pipe(catchError(() => of([]))),
+    }).subscribe(({ team, teamAdvances }) => {
+      this.teamReports.set(team);
+      this.teamAdvances.set(teamAdvances);
+    });
   }
 
-  getReportStatusColor(status: string): string {
-    return this.REPORT_STATUS_COLORS[status] || 'bg-gray-100 text-gray-600';
+  // ─── Aprobaciones inline (coordinador) ────────────────────────────
+  /** ¿El coordinador puede aprobar esta fila según su tipo y estado? */
+  canApproveRow(row: DashRow, kind: 'solicitud' | 'rendicion'): boolean {
+    if (kind === 'rendicion') return true; // aprobación de comprobantes a nivel reporte
+    if (row.status === 'pending_l1') return this.canApproveL1;
+    if (row.status === 'pending_l2') return this.canApproveL2;
+    return false;
   }
 
-  getAdvanceReportTitle(advance: IAdvance): string {
-    if (typeof advance.expenseReportId === 'object' && advance.expenseReportId) {
-      return advance.expenseReportId.title;
+  approveRow(row: DashRow, kind: 'solicitud' | 'rendicion', event: Event) {
+    event.stopPropagation();
+
+    // Rendición: la aprobación es por comprobante (y depende de la validación previa
+    // de Contabilidad), estado que la lista no conoce. Llevamos al detalle, donde el
+    // coordinador aprueba con el estado real por comprobante.
+    if (kind === 'rendicion') {
+      this.goToRow(row);
+      return;
+    }
+
+    if (this.acting()) return;
+    this.acting.set(row._id);
+
+    // Solicitud de viáticos: cambio de estado limpio (pending_l1/l2). El viático puede
+    // venir como reporte (modelo nuevo) o como advance (legacy): cada uno tiene su
+    // propio endpoint de aprobación, igual que en /rendiciones.
+    const isL1 = row.status === 'pending_l1';
+    const call$: Observable<unknown> = row.source === 'advance'
+      ? (isL1 ? this.advanceService.approveL1(row._id, {}) : this.advanceService.approveL2(row._id, {}))
+      : (isL1 ? this.expenseReportsService.approveViaticoL1(row._id) : this.expenseReportsService.approveViaticoL2(row._id));
+    call$.subscribe({
+      next: () => {
+        this.acting.set(null);
+        this.notifications.show('Solicitud aprobada.', 'success');
+        this.reloadCoordinador();
+      },
+      error: (e: any) => {
+        this.acting.set(null);
+        this.notifications.show(e?.error?.message || 'Error al aprobar la solicitud', 'error');
+      },
+    });
+  }
+
+  // ─── Mapeo a filas ────────────────────────────────────────────────
+  private reportRow(r: IExpenseReport): DashRow {
+    return {
+      _id: r._id,
+      source: 'report',
+      title: r.title || (r as any).viaticoPlace || '—',
+      userName: this.resolveUserName(r.userId),
+      project: this.resolveProject((r as any).projectId),
+      amount: (r as any).viaticoAmount ?? r.budget ?? 0,
+      status: r.status,
+      statusLabel: this.REPORT_STATUS_LABELS[r.status] ?? r.status,
+      statusColor: this.REPORT_STATUS_COLORS[r.status] ?? 'bg-gray-100 text-gray-600',
+      createdAt: r.createdAt,
+    };
+  }
+
+  private advanceRow(a: IAdvance): DashRow {
+    return {
+      _id: a._id,
+      source: 'advance',
+      title: (a as any).place || (a as any).description || '—',
+      userName: this.resolveUserName(a.userId),
+      project: this.resolveProject((a as any).projectId),
+      amount: (a as any).amount ?? 0,
+      status: a.status,
+      statusLabel: this.STATUS_LABELS[a.status] ?? a.status,
+      statusColor: this.STATUS_COLORS[a.status] ?? 'bg-gray-100 text-gray-600',
+      createdAt: a.createdAt,
+    };
+  }
+
+  private resolveUserName(userId: unknown): string {
+    if (userId && typeof userId === 'object') {
+      return (userId as any).name || (userId as any).email || '—';
     }
     return '—';
   }
 
-  getAdvanceReportId(advance: IAdvance): string | null {
-    if (!advance.expenseReportId) return null;
-    if (typeof advance.expenseReportId === 'object') {
-      return advance.expenseReportId._id;
+  /** Etiqueta del proyecto (código — nombre) si viene poblado. */
+  private resolveProject(projectId: unknown): string {
+    if (projectId && typeof projectId === 'object') {
+      const p = projectId as any;
+      return p.code ? `${p.code} — ${p.name}` : (p.name ?? '');
     }
-    return advance.expenseReportId;
+    return '';
   }
 
-  navigateToExpenseReport(advance: IAdvance) {
-    const reportId = this.getAdvanceReportId(advance);
-    if (reportId) {
-      this.router.navigate(['/mis-rendiciones', reportId, 'detalle']);
+  // ─── Helpers de estilo para tarjetas KPI reutilizables ────────────
+  private readonly ACCENT_BG: Record<string, string> = {
+    yellow: 'bg-yellow-100', blue: 'bg-blue-100', purple: 'bg-purple-100',
+    primary: 'bg-primary/10', red: 'bg-red-100',
+  };
+  private readonly ACCENT_TEXT: Record<string, string> = {
+    yellow: 'text-yellow-600', blue: 'text-blue-600', purple: 'text-purple-600',
+    primary: 'text-primary', red: 'text-red-600',
+  };
+  iconBg(accent: string, active: boolean): string {
+    return active ? (this.ACCENT_BG[accent] ?? 'bg-gray-100') : 'bg-gray-100';
+  }
+  iconText(accent: string, active: boolean): string {
+    return active ? (this.ACCENT_TEXT[accent] ?? 'text-tertiary') : 'text-tertiary';
+  }
+
+  private isPendingApproval(status: string): boolean {
+    return status === 'pending_l1' || status === 'pending_l2';
+  }
+
+  private ts(date: string | undefined): number {
+    return date ? new Date(date).getTime() : 0;
+  }
+
+  // ─── Navegación ───────────────────────────────────────────────────
+  goToRow(row: DashRow) {
+    if (row.source === 'advance') {
+      this.router.navigate(['/viaticos', row._id]);
     } else {
-      this.router.navigate(['/mis-rendiciones']);
+      this.router.navigate(['/mis-rendiciones', row._id, 'detalle']);
     }
-  }
-
-  get saldoLibreTotal(): number {
-    return this.kpiPresupuestoTotal() - this.kpiGastado();
-  }
-
-  get porcentajeEjecutado(): number {
-    const total = this.kpiPresupuestoTotal();
-    if (!total) return 0;
-    return Math.min(100, Math.round((this.kpiGastado() / total) * 100));
   }
 }


### PR DESCRIPTION
…iones directas

- Coordinador: "Aprobaciones de mi equipo" (solicitudes + rendiciones por aprobar con aprobación inline) y "Mi actividad" (rendiciones propias).
- Colaborador/Mi actividad: separa Viáticos (solicitudes + rendiciones) de Rendiciones directas, con tarjeta "Por enviar a revisión" por sección.
- Tarjetas/listas gateadas por permisos (mis-rendiciones / nueva-rendicion).
- Fila con proyecto; listados 5 + expandir; campo de bolsa.