### PR TITLE
fix(mis-rendiciones): mostrar eliminar en directa con saldo heredado …

### DIFF
--- a/src/app/modules/mis-rendiciones/mis-rendiciones.component.ts
+++ b/src/app/modules/mis-rendiciones/mis-rendiciones.component.ts
@@ -689,9 +689,15 @@ export class MisRendicionesComponent implements OnInit {
     const noExpenseApproval = !report.hasApprovedExpense;
     if (!noReportApproval || !noExpenseApproval) return false;
 
-    // Rendición directa creada por Contabilidad para el colaborador, o creada con
-    // saldo heredado de otra: no la puede eliminar (solo Contabilidad).
-    if (report.isDirecta && (report.createdByOther || report.inheritedBalance))
+    // Rendición directa creada por Contabilidad para el colaborador: no la puede
+    // eliminar (solo Contabilidad).
+    if (report.isDirecta && report.createdByOther) return false;
+
+    // Rendición directa con saldo heredado de otra: el dueño puede eliminarla
+    // MIENTRAS no haya subido ningún gasto (el borrado devuelve el saldo a la
+    // bolsa y libera la rendición de origen). Con gastos ya cargados, solo
+    // Contabilidad. Espeja la validación del backend (remove).
+    if (report.isDirecta && report.inheritedBalance && (report.expenseIds?.length ?? 0) > 0)
       return false;
 
     // Caja chica ya jalada por Contabilidad (borrador o finalizado): no la puede


### PR DESCRIPTION
…sin gastos

canDeleteReport ocultaba el boton de eliminar para toda directa con saldo heredado. Ahora separa createdByOther (siempre bloquea) de inheritedBalance (bloquea solo si ya hay gastos cargados), espejando el backend: el dueño puede eliminar su directa heredada mientras no haya subido gastos.