### PR TITLE
feat(viaticos): presupuesto = total solicitado y popup de detalle de …

### DIFF
--- a/src/app/modules/admin-users/rendiciones-admin/rendiciones-admin.component.html
+++ b/src/app/modules/admin-users/rendiciones-admin/rendiciones-admin.component.html
@@ -548,3 +548,10 @@
   </div>
 </div>
 }
+
+<!-- Popup: detalle de solicitud de viático -->
+<app-viatico-solicitud-detail
+  [report]="viaticoDetailReport"
+  [userName]="viaticoDetailItem()?.userName ?? ''"
+  [projectName]="viaticoDetailItem()?.projectName ?? ''"
+  (closed)="viaticoDetailItem.set(null)" />

--- a/src/app/modules/admin-users/rendiciones-admin/rendiciones-admin.component.ts
+++ b/src/app/modules/admin-users/rendiciones-admin/rendiciones-admin.component.ts
@@ -14,6 +14,7 @@ import { IExpenseReport } from '../../../interfaces/expense-report.interface';
 import { IAdvance, ADVANCE_STATUS_LABELS, ADVANCE_STATUS_COLORS } from '../../../interfaces/advance.interface';
 import { IUserResponse } from '../../../interfaces/user.interface';
 import { IProject } from '../../invoices/interfaces/project.interface';
+import { ViaticoSolicitudDetailComponent } from '../../viaticos/viatico-solicitud-detail/viatico-solicitud-detail.component';
 
 const REPORT_STATUS_LABELS: Record<string, string> = {
   // Rendición normal
@@ -76,7 +77,7 @@ export type UnifiedRendicionItem = {
 @Component({
   selector: 'app-rendiciones-admin',
   standalone: true,
-  imports: [CommonModule, FormsModule, ReactiveFormsModule, RouterModule],
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, RouterModule, ViaticoSolicitudDetailComponent],
   templateUrl: './rendiciones-admin.component.html',
 })
 export class RendicionesAdminComponent implements OnInit {
@@ -301,7 +302,34 @@ export class RendicionesAdminComponent implements OnInit {
     return !!(this.filterUserId || this.filterProjectId || this.filterDateFrom || this.filterDateTo);
   }
 
+  // Detalle de solicitud de viático (popup): coordinador/contabilidad ven lo solicitado
+  // (lugar, fechas, líneas por categoría, montos) sin salir de la vista.
+  viaticoDetailItem = signal<UnifiedRendicionItem | null>(null);
+
+  get viaticoDetailReport(): IExpenseReport | null {
+    const it = this.viaticoDetailItem();
+    return it ? (it.raw as IExpenseReport) : null;
+  }
+
+  /**
+   * Fase de solicitud de un viático: aún no se paga/abre para registrar gastos.
+   * En esta fase el "Ver detalle" abre el popup con la solicitud; una vez que el
+   * colaborador ya está registrando gastos (open/partially_paid y posteriores) el
+   * botón navega directo a la rendición.
+   */
+  isViaticoSolicitud(status: string): boolean {
+    return ['pending_l1', 'pending_l2', 'viatico_approved'].includes(status);
+  }
+
   goToDetail(item: UnifiedRendicionItem): void {
+    if (
+      item.source === 'report' &&
+      (item.raw as IExpenseReport).type === 'viatico' &&
+      this.isViaticoSolicitud((item.raw as IExpenseReport).status)
+    ) {
+      this.viaticoDetailItem.set(item);
+      return;
+    }
     if (item.source === 'advance') {
       this.router.navigate(['/viaticos', item._id]);
     } else {

--- a/src/app/modules/mis-rendiciones/rendicion-detail/rendicion-detail.component.html
+++ b/src/app/modules/mis-rendiciones/rendicion-detail/rendicion-detail.component.html
@@ -670,6 +670,70 @@
         </div>
       </div>
       }
+      } @else if (isViatico) {
+      <!-- Viáticos: el Presupuesto es el TOTAL solicitado; el Saldo Disponible refleja solo
+           lo ya financiado (saldo heredado/bolsa + depósito de Contabilidad). -->
+      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 sm:gap-6 mb-6 md:mb-8">
+        <!-- Presupuesto (total solicitado) -->
+        <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4 sm:p-6">
+          <div class="flex items-center gap-3 mb-2">
+            <div class="p-2 bg-blue-50 text-blue-600 rounded-lg">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18.75a60.07 60.07 0 0 1 15.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 0 1 3 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 0 0-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 0 1-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 0 0 3 15h-.75M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm3 0h.008v.008H18V10.5Zm-12 0h.008v.008H6V10.5Z" />
+              </svg>
+            </div>
+            <p class="font-medium text-gray-500">Presupuesto</p>
+          </div>
+          <p class="text-2xl sm:text-3xl font-bold text-gray-900 tabular-nums">S/ {{ viaticoPresupuesto | number:'1.2-2' }}</p>
+          @if (viaticoFinancingRows.length > 0 || viaticoPendienteDeposito > 0) {
+          <div class="mt-3 border-t border-gray-100 pt-2 space-y-1.5">
+            <p class="text-[11px] font-semibold text-gray-400 uppercase tracking-wider">Financiamiento</p>
+            @for (row of viaticoFinancingRows; track row.label) {
+            <div class="flex justify-between gap-2 text-xs">
+              <span class="text-gray-500 truncate">{{ row.label }}</span>
+              <span class="font-medium text-gray-700 shrink-0 tabular-nums">S/ {{ row.amount | number:'1.2-2' }}</span>
+            </div>
+            }
+            @if (viaticoPendienteDeposito > 0) {
+            <div class="flex justify-between gap-2 text-xs pt-1.5 border-t border-gray-50">
+              <span class="text-amber-600 truncate">Pendiente de depósito de Contabilidad</span>
+              <span class="font-semibold text-amber-600 shrink-0 tabular-nums">S/ {{ viaticoPendienteDeposito | number:'1.2-2' }}</span>
+            </div>
+            }
+          </div>
+          }
+        </div>
+        <!-- Total gastado -->
+        <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4 sm:p-6">
+          <div class="flex items-center gap-3 mb-2">
+            <div class="p-2 bg-red-50 text-red-600 rounded-lg">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+              </svg>
+            </div>
+            <p class="font-medium text-gray-500">Total Gastado</p>
+          </div>
+          <p class="text-2xl sm:text-3xl font-bold text-gray-900 tabular-nums">S/ {{ totalGastado | number:'1.2-2' }}</p>
+        </div>
+        <!-- Saldo disponible -->
+        <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4 sm:p-6">
+          <div class="flex items-center gap-3 mb-2">
+            <div class="p-2 bg-green-50 text-green-600 rounded-lg">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+              </svg>
+            </div>
+            <p class="font-medium text-gray-500">Saldo Disponible</p>
+          </div>
+          @if (isSaldoUsadoEnOtraRendicion) {
+          <p class="text-sm font-semibold text-amber-700">Saldo utilizado en otra solicitud (S/ {{ saldoLibre | number:'1.2-2' }}) trasladado a nueva solicitud</p>
+          } @else {
+          <p class="text-2xl sm:text-3xl font-bold tabular-nums" [ngClass]="{'text-green-600': saldoLibre >= 0, 'text-red-600': saldoLibre < 0}">
+            S/ {{ saldoLibre | number:'1.2-2' }}
+          </p>
+          }
+        </div>
+      </div>
       } @else {
       <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 sm:gap-6 mb-6 md:mb-8">
         <!-- Budget assigned -->
@@ -2211,7 +2275,7 @@
         @if (!report.isDirecta) {
         <div class="flex justify-between text-sm">
           <span class="text-gray-500">Presupuesto asignado</span>
-          <span class="font-semibold text-gray-900">S/ {{ totalAnticipado | number:'1.2-2' }}</span>
+          <span class="font-semibold text-gray-900">S/ {{ presupuestoDisplay | number:'1.2-2' }}</span>
         </div>
         }
         @if (hasDirectaDeposit) {
@@ -2316,7 +2380,7 @@
       </div>
       <div class="flex justify-between gap-4">
         <span class="text-gray-500">Presupuesto</span>
-        <span class="font-semibold text-gray-900 tabular-nums">S/ {{ totalAnticipado | number:'1.2-2' }}</span>
+        <span class="font-semibold text-gray-900 tabular-nums">S/ {{ presupuestoDisplay | number:'1.2-2' }}</span>
       </div>
       <div class="flex justify-between gap-4">
         <span class="text-gray-500">Total gastado</span>

--- a/src/app/modules/mis-rendiciones/rendicion-detail/rendicion-detail.component.ts
+++ b/src/app/modules/mis-rendiciones/rendicion-detail/rendicion-detail.component.ts
@@ -1656,13 +1656,30 @@ export class RendicionDetailComponent implements OnInit, OnDestroy {
       });
     }
     // Viático: lo pagado por contabilidad (viaticoPaidAmount menos lo cubierto por el
-    // saldo de la bolsa, que ya figura aparte en financiamientoSaldos) es un ingreso.
+    // saldo de la bolsa y por el saldo heredado, que figuran aparte) es un ingreso.
     if (this.report.type === 'viatico') {
       const viaticoPaid = Number(
         (this.report as { viaticoPaidAmount?: number }).viaticoPaidAmount ?? 0
       );
-      const bolsaTotal = this.hasFinancingSaldos ? this.financingSaldosTotal : 0;
-      const deposito = Math.round((viaticoPaid - bolsaTotal) * 100) / 100;
+      // Saldo heredado de otra rendición: es un ingreso propio (no un depósito de
+      // Contabilidad). Se acota a lo realmente aplicado (viaticoPaid − bolsa).
+      const heredado = this.viaticoHeredadoAplicado;
+      if (heredado > 0.01) {
+        const origenCodigo = this.report.pendingBalanceFromCodigo;
+        const rawDate = this.report.createdAt;
+        const fechaSolicitud = rawDate ? this.formatEmissionDate(rawDate) : '—';
+        anticipos.unshift({
+          descripcion: origenCodigo
+            ? `Saldo heredado (${origenCodigo})`
+            : 'Saldo heredado (rendición anterior)',
+          monto: heredado,
+          estado: 'Traspasado',
+          fechaSolicitud,
+        });
+      }
+      // Depósito de Contabilidad = lo pagado menos lo cubierto por heredado y por la bolsa
+      // (esta última acotada a lo realmente aplicado, no al monto total del saldo consumido).
+      const deposito = Math.round((viaticoPaid - this.viaticoBolsaAplicadaTotal - heredado) * 100) / 100;
       if (deposito > 0.01) {
         const pagos = (
           this.report as {
@@ -1692,13 +1709,16 @@ export class RendicionDetailComponent implements OnInit, OnDestroy {
       gestion: this.report.gestion || undefined,
       descripcionRendicion: this.report.description || undefined,
       financiamientoSaldos: this.hasFinancingSaldos
-        ? this.financingSaldos.map(s => ({
-            tipo: this.financingSaldoTipo(s),
-            detalle: this.financingSaldoLabel(s),
-            monto: Number(s.amount) || 0,
-            fecha: s.deposit?.operationDate
-              || (s.createdAt ? new Date(s.createdAt).toLocaleDateString('es-PE') : ''),
-          }))
+        ? this.viaticoSaldosAplicados
+            .filter(({ amount }) => amount > 0.01 || !this.isViatico)
+            .map(({ saldo: s, amount }) => ({
+              tipo: this.financingSaldoTipo(s),
+              detalle: this.financingSaldoLabel(s),
+              // En viáticos, el monto realmente aplicado (el excedente ya volvió a la bolsa).
+              monto: this.isViatico ? amount : (Number(s.amount) || 0),
+              fecha: s.deposit?.operationDate
+                || (s.createdAt ? new Date(s.createdAt).toLocaleDateString('es-PE') : ''),
+            }))
         : undefined,
       colaborador: this.getCollaboratorDisplayName(),
       presupuesto: this.report.budget ?? 0,
@@ -2246,6 +2266,120 @@ export class RendicionDetailComponent implements OnInit, OnDestroy {
     return codigo
       ? `Traspasado desde ${codigo}`
       : 'Traspasado desde rendición anterior';
+  }
+
+  /** Es una rendición de viáticos (type='viatico'). */
+  get isViatico(): boolean {
+    return this.report?.type === 'viatico';
+  }
+
+  /**
+   * Presupuesto de un viático: el TOTAL solicitado (viaticoAmount), independientemente
+   * de cuánto se haya financiado ya con saldo heredado/bolsa o depositado Contabilidad.
+   * El "Saldo Disponible" (saldoLibre) sí refleja solo lo ya financiado.
+   */
+  get viaticoPresupuesto(): number {
+    return Number((this.report as any)?.viaticoAmount ?? this.report?.budget ?? 0);
+  }
+
+  /** Parte del viático ya financiada (saldo heredado/bolsa + depósitos de Contabilidad). */
+  get viaticoFinanciado(): number {
+    return Number((this.report as any)?.viaticoPaidAmount ?? 0);
+  }
+
+  /** Monto que Contabilidad aún debe depositar para completar el presupuesto del viático. */
+  get viaticoPendienteDeposito(): number {
+    const pend = Math.round((this.viaticoPresupuesto - this.viaticoFinanciado) * 100) / 100;
+    return pend > 0.01 ? pend : 0;
+  }
+
+  /** El viático fue financiado (total o parcialmente) con el saldo heredado de otra rendición. */
+  get hasViaticoInheritedBalance(): boolean {
+    return !!(this.isViatico
+      && this.report?.pendingBalanceFromReportId
+      && (this.report?.pendingBalanceAmount ?? 0) > 0);
+  }
+
+  /**
+   * Saldo heredado realmente aplicado a este viático: acotado a lo financiado
+   * (viaticoPaidAmount − saldos de la bolsa), sin el excedente que ya volvió a la bolsa
+   * cuando el heredado superaba el total. Así el desglose siempre cuadra:
+   * heredado aplicado + bolsa + pendiente de depósito = presupuesto.
+   */
+  get viaticoHeredadoAplicado(): number {
+    if (!this.hasViaticoInheritedBalance) return 0;
+    const bolsaTotal = this.hasFinancingSaldos ? this.financingSaldosTotal : 0;
+    const aplicado = Math.round((this.viaticoFinanciado - bolsaTotal) * 100) / 100;
+    return Math.min(this.pendingBalanceCreditAmount, Math.max(aplicado, 0));
+  }
+
+  /**
+   * Saldos de la bolsa con el monto REALMENTE aplicado a este viático (no el monto total
+   * del saldo consumido). Cuando el saldo supera el costo del viático, solo se usa lo
+   * necesario y el excedente vuelve a la bolsa como otro saldo; aquí lo acotamos a lo
+   * financiado (viaticoPaidAmount − saldo heredado) para no sobre-contar.
+   */
+  get viaticoSaldosAplicados(): { saldo: IReportFinancingSaldo; amount: number }[] {
+    let restante = this.isViatico
+      ? Math.max(
+          Math.round((this.viaticoFinanciado - this.viaticoHeredadoAplicado) * 100) / 100,
+          0
+        )
+      : Number.POSITIVE_INFINITY;
+    const out: { saldo: IReportFinancingSaldo; amount: number }[] = [];
+    for (const s of this.financingSaldos) {
+      const full = Number(s.amount) || 0;
+      const amount = Math.round(Math.min(full, restante) * 100) / 100;
+      out.push({ saldo: s, amount });
+      restante = Math.round((restante - amount) * 100) / 100;
+    }
+    return out;
+  }
+
+  /** Total del saldo de la bolsa realmente aplicado a este viático (capado). */
+  get viaticoBolsaAplicadaTotal(): number {
+    return Math.round(
+      this.viaticoSaldosAplicados.reduce((a, r) => a + r.amount, 0) * 100
+    ) / 100;
+  }
+
+  /**
+   * Desglose del presupuesto de un viático (composición del monto ya financiado): saldo
+   * heredado + saldos de la bolsa (capados) + depósito de Contabilidad. La suma de estas
+   * filas es viaticoPaidAmount; lo que falte hasta el total va en `viaticoPendienteDeposito`.
+   */
+  get viaticoFinancingRows(): { label: string; amount: number }[] {
+    if (!this.isViatico) return [];
+    const rows: { label: string; amount: number }[] = [];
+    if (this.viaticoHeredadoAplicado > 0.01) {
+      rows.push({
+        label: `Saldo heredado · ${this.pendingBalanceFromLabel}`,
+        amount: this.viaticoHeredadoAplicado,
+      });
+    }
+    for (const { saldo, amount } of this.viaticoSaldosAplicados) {
+      if (amount <= 0.01) continue;
+      const detalle = this.financingSaldoLabel(saldo);
+      rows.push({
+        label: `${this.financingSaldoTipo(saldo)}${detalle ? ' · ' + detalle : ''}`,
+        amount,
+      });
+    }
+    const deposito = Math.round(
+      (this.viaticoFinanciado - this.viaticoHeredadoAplicado - this.viaticoBolsaAplicadaTotal) * 100
+    ) / 100;
+    if (deposito > 0.01) {
+      rows.push({ label: 'Depósito de Contabilidad', amount: deposito });
+    }
+    return rows;
+  }
+
+  /**
+   * Presupuesto a mostrar en resúmenes/modales: el total solicitado para viáticos,
+   * lo anticipado para el resto de rendiciones.
+   */
+  get presupuestoDisplay(): number {
+    return this.isViatico ? this.viaticoPresupuesto : this.totalAnticipado;
   }
 
   /** Devuelve true cuando el saldo esperado corresponde a una devolución del colaborador. */

--- a/src/app/modules/tesoreria/tesoreria.component.html
+++ b/src/app/modules/tesoreria/tesoreria.component.html
@@ -339,10 +339,10 @@
               </td>
               <td class="px-5 py-3.5 text-right">
                 <div class="flex items-center justify-end gap-2">
-                  <a [routerLink]="['/mis-rendiciones', rep._id, 'detalle']"
+                  <button type="button" (click)="openViaticoDetail(rep)"
                     class="text-xs px-3 py-1.5 border border-tertiary/30 text-secondary rounded-lg hover:bg-background transition-colors font-medium">
                     Detalle
-                  </a>
+                  </button>
                   <button type="button" (click)="openViaticoPaymentModal(rep)" [disabled]="isActing()"
                     class="text-xs px-3 py-1.5 bg-primary text-white rounded-lg hover:bg-primary/90 disabled:opacity-50 font-medium transition-colors">
                     {{ (rep.viaticoPaidAmount ?? 0) > 0 ? 'Pago parcial' : 'Registrar pago' }}
@@ -369,10 +369,10 @@
               </td>
               <td class="px-5 py-3.5 text-right">
                 <div class="flex items-center justify-end gap-2">
-                  <a [routerLink]="['/mis-rendiciones', rep._id, 'detalle']"
+                  <button type="button" (click)="openViaticoDetail(rep)"
                     class="text-xs px-3 py-1.5 border border-tertiary/30 text-secondary rounded-lg hover:bg-background transition-colors font-medium">
                     Detalle
-                  </a>
+                  </button>
                   @if (canCompleteViaticoPayment(rep)) {
                   <button type="button" (click)="openViaticoPaymentModal(rep)" [disabled]="isActing()"
                     class="text-xs px-3 py-1.5 bg-primary text-white rounded-lg hover:bg-primary/90 disabled:opacity-50 transition-colors font-medium">
@@ -464,10 +464,10 @@
             </div>
           </div>
           <div class="flex gap-2">
-            <a [routerLink]="['/mis-rendiciones', rep._id, 'detalle']"
+            <button type="button" (click)="openViaticoDetail(rep)"
               class="text-xs px-3 py-1.5 border border-tertiary/30 text-secondary rounded-lg hover:bg-background transition-colors font-medium">
               Detalle
-            </a>
+            </button>
             <button type="button" (click)="openViaticoPaymentModal(rep)" [disabled]="isActing()"
               class="flex-1 text-xs px-3 py-1.5 bg-primary text-white rounded-lg hover:bg-primary/90 disabled:opacity-50 font-medium transition-colors">
               {{ (rep.viaticoPaidAmount ?? 0) > 0 ? 'Pago parcial' : 'Registrar pago' }}
@@ -494,10 +494,10 @@
             </div>
           </div>
           <div class="flex gap-2">
-            <a [routerLink]="['/mis-rendiciones', rep._id, 'detalle']"
+            <button type="button" (click)="openViaticoDetail(rep)"
               class="text-xs px-3 py-1.5 border border-tertiary/30 text-secondary rounded-lg hover:bg-background transition-colors font-medium">
               Detalle
-            </a>
+            </button>
             @if (canCompleteViaticoPayment(rep)) {
             <button type="button" (click)="openViaticoPaymentModal(rep)" [disabled]="isActing()"
               class="flex-1 text-xs px-3 py-1.5 bg-primary text-white rounded-lg hover:bg-primary/90 disabled:opacity-50 font-medium transition-colors">
@@ -1189,4 +1189,11 @@
   </div>
 </div>
 }
+
+<!-- Popup: detalle de solicitud de viático -->
+<app-viatico-solicitud-detail
+  [report]="viaticoDetailReport()"
+  [userName]="viaticoDetailReport() ? viaticoUserName(viaticoDetailReport()!) : ''"
+  [projectName]="viaticoDetailReport() ? viaticoProjectName(viaticoDetailReport()!) : ''"
+  (closed)="viaticoDetailReport.set(null)" />
 

--- a/src/app/modules/tesoreria/tesoreria.component.ts
+++ b/src/app/modules/tesoreria/tesoreria.component.ts
@@ -14,12 +14,13 @@ import {
 import { ExpenseReportsService } from '../../services/expense-reports.service';
 import { IExpenseReport } from '../../interfaces/expense-report.interface';
 import { RouterModule, Router, ActivatedRoute } from '@angular/router';
+import { ViaticoSolicitudDetailComponent } from '../viaticos/viatico-solicitud-detail/viatico-solicitud-detail.component';
 type Tab = 'pendientes' | 'aprobados' | 'devoluciones' | 'rendiciones-directas';
 
 @Component({
   selector: 'app-tesoreria',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, RouterModule],
+  imports: [CommonModule, ReactiveFormsModule, RouterModule, ViaticoSolicitudDetailComponent],
   templateUrl: './tesoreria.component.html',
 })
 export class TesoreriaComponent implements OnInit {
@@ -50,6 +51,8 @@ export class TesoreriaComponent implements OnInit {
   selectedReportReimbursement: IExpenseReport | null = null;
   selectedViaticoReport: IExpenseReport | null = null;
   showViaticoPaymentModal = false;
+  /** Reporte mostrado en el popup de detalle de solicitud de viático. */
+  viaticoDetailReport = signal<IExpenseReport | null>(null);
   viaticoPaymentReceiptUrl: string | null = null;
   viaticoPaymentReceiptName: string | null = null;
   viaticoPaymentReceiptMimeType: string | null = null;
@@ -256,6 +259,33 @@ export class TesoreriaComponent implements OnInit {
 
   viaticoRemaining(report: IExpenseReport): number {
     return Math.max(Number(report.viaticoAmount ?? 0) - Number(report.viaticoPaidAmount ?? 0), 0);
+  }
+
+  /** Nombre del centro de costo (projectId poblado) para el popup de detalle. */
+  viaticoProjectName(report: IExpenseReport): string {
+    const p = report.projectId as any;
+    if (p && typeof p === 'object') {
+      return p.code ? `${p.code} — ${p.name ?? ''}`.trim() : (p.name ?? '—');
+    }
+    return '—';
+  }
+
+  /**
+   * Fase de solicitud de un viático: aún no se paga/abre para registrar gastos.
+   * En esa fase se muestra el popup; si el colaborador ya está registrando gastos
+   * (open/partially_paid y posteriores) se navega directo a la rendición.
+   */
+  isViaticoSolicitud(status: string): boolean {
+    return ['pending_l1', 'pending_l2', 'viatico_approved'].includes(status);
+  }
+
+  /** "Detalle" de un viático: popup si sigue en solicitud, si no navega a la rendición. */
+  openViaticoDetail(report: IExpenseReport): void {
+    if (this.isViaticoSolicitud(report.status)) {
+      this.viaticoDetailReport.set(report);
+    } else {
+      this.router.navigate(['/mis-rendiciones', report._id, 'detalle']);
+    }
   }
 
   /**

--- a/src/app/modules/viaticos/viatico-solicitud-detail/viatico-solicitud-detail.component.html
+++ b/src/app/modules/viaticos/viatico-solicitud-detail/viatico-solicitud-detail.component.html
@@ -1,0 +1,208 @@
+@if (report) {
+<div class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-secondary/50 backdrop-blur-sm"
+     (click)="close()">
+  <div class="bg-quaternary rounded-2xl shadow-xl border border-tertiary/20 w-full max-w-2xl max-h-[90vh] overflow-y-auto"
+       (click)="$event.stopPropagation()">
+
+    <!-- Header -->
+    <div class="flex items-start justify-between gap-3 p-6 pb-4 border-b border-tertiary/10 sticky top-0 bg-quaternary z-10">
+      <div class="flex items-center gap-3 min-w-0">
+        <div class="w-11 h-11 rounded-xl bg-primary/15 text-primary flex items-center justify-center shrink-0">
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.75" d="M9 6.75V15m6-6v8.25m.503 3.498 4.875-2.437c.381-.19.622-.58.622-1.006V4.82c0-.836-.88-1.38-1.628-1.006l-3.869 1.934c-.317.159-.69.159-1.006 0L9.503 3.252a1.125 1.125 0 0 0-1.006 0L3.622 5.689C3.24 5.879 3 6.27 3 6.695V19.18c0 .836.88 1.38 1.628 1.006l3.869-1.934c.317-.159.69-.159 1.006 0l4.994 2.497c.317.158.69.158 1.006 0Z"/>
+          </svg>
+        </div>
+        <div class="min-w-0">
+          <h2 class="text-base font-bold text-secondary truncate">Solicitud de viáticos</h2>
+          <p class="text-xs text-tertiary mt-0.5 truncate">{{ report.viaticoPlace || report.title || '—' }}</p>
+        </div>
+      </div>
+      <div class="flex items-center gap-2 shrink-0">
+        <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold" [class]="statusColor">
+          {{ statusLabel }}
+        </span>
+        <button (click)="close()" class="p-1.5 rounded-lg text-tertiary hover:text-secondary hover:bg-background transition-colors" title="Cerrar">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+          </svg>
+        </button>
+      </div>
+    </div>
+
+    <div class="p-6 pt-4 space-y-5">
+
+      <!-- Datos generales -->
+      <div class="grid grid-cols-2 sm:grid-cols-3 gap-x-6 gap-y-3">
+        @if (userName) {
+        <div>
+          <span class="block text-tertiary uppercase tracking-wide text-[10px] font-semibold">Colaborador</span>
+          <span class="text-sm text-secondary break-words">{{ userName }}</span>
+        </div>
+        }
+        @if (projectName) {
+        <div>
+          <span class="block text-tertiary uppercase tracking-wide text-[10px] font-semibold">Centro de costo</span>
+          <span class="text-sm text-secondary break-words">{{ projectName }}</span>
+        </div>
+        }
+        <div>
+          <span class="block text-tertiary uppercase tracking-wide text-[10px] font-semibold">Lugar</span>
+          <span class="text-sm text-secondary break-words">{{ report.viaticoPlace || '—' }}</span>
+        </div>
+        <div>
+          <span class="block text-tertiary uppercase tracking-wide text-[10px] font-semibold">Desde</span>
+          <span class="text-sm text-secondary">{{ report.viaticoStartDate ? (report.viaticoStartDate | date:'dd/MM/yyyy') : '—' }}</span>
+        </div>
+        <div>
+          <span class="block text-tertiary uppercase tracking-wide text-[10px] font-semibold">Hasta</span>
+          <span class="text-sm text-secondary">{{ report.viaticoEndDate ? (report.viaticoEndDate | date:'dd/MM/yyyy') : '—' }}</span>
+        </div>
+        <div>
+          <span class="block text-tertiary uppercase tracking-wide text-[10px] font-semibold">Solicitado</span>
+          <span class="text-sm text-secondary">{{ report.createdAt ? (report.createdAt | date:'dd/MM/yyyy') : '—' }}</span>
+        </div>
+      </div>
+
+      @if (report.viaticoObservations) {
+      <div>
+        <span class="block text-tertiary uppercase tracking-wide text-[10px] font-semibold mb-1">Observaciones</span>
+        <p class="text-sm text-secondary whitespace-pre-line break-words">{{ report.viaticoObservations }}</p>
+      </div>
+      }
+
+      <!-- Detalle por categoría -->
+      @if (lines.length > 0) {
+      <div>
+        <p class="text-xs font-semibold text-tertiary uppercase tracking-wider mb-2">Detalle por categoría</p>
+
+        <!-- Móvil: acordeón -->
+        <div class="md:hidden rounded-xl border border-tertiary/15 divide-y divide-tertiary/10 overflow-hidden">
+          @for (ln of lines; track $index) {
+          <div>
+            <button type="button" (click)="toggleLine($index)"
+              class="w-full flex items-center justify-between gap-2 px-3 py-2.5 text-left hover:bg-background transition-colors">
+              <div class="min-w-0">
+                <span class="block text-xs font-medium text-secondary truncate">{{ categoryName(ln) }}</span>
+                @if (ln.detalle) { <span class="block text-xs text-tertiary truncate">{{ ln.detalle }}</span> }
+              </div>
+              <div class="flex items-center gap-2 shrink-0">
+                <span class="text-sm font-bold text-secondary tabular-nums">S/ {{ ln.lineTotal | number:'1.2-2' }}</span>
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"
+                  class="w-3.5 h-3.5 text-tertiary transition-transform duration-200"
+                  [class.-rotate-180]="isLineExpanded($index)">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+                </svg>
+              </div>
+            </button>
+            @if (isLineExpanded($index)) {
+            <div class="px-3 pt-2 pb-2.5 flex flex-wrap gap-x-5 gap-y-1 text-xs text-tertiary">
+              <span>Importe <span class="font-medium text-secondary tabular-nums">S/ {{ ln.importe | number:'1.2-2' }}</span></span>
+              <span>Pers. <span class="font-medium text-secondary tabular-nums">{{ ln.peopleCount }}</span></span>
+              <span>Días <span class="font-medium text-secondary tabular-nums">{{ ln.days }}</span></span>
+            </div>
+            }
+          </div>
+          }
+        </div>
+
+        <!-- Desktop: tabla -->
+        <div class="hidden md:block rounded-xl border border-tertiary/15 overflow-hidden">
+          <table class="min-w-full text-xs">
+            <thead class="bg-background">
+              <tr>
+                <th class="px-3 py-2 text-left font-semibold text-tertiary">Categoría</th>
+                <th class="px-3 py-2 text-right font-semibold text-tertiary">Importe</th>
+                <th class="px-3 py-2 text-right font-semibold text-tertiary">Pers.</th>
+                <th class="px-3 py-2 text-right font-semibold text-tertiary">Días</th>
+                <th class="px-3 py-2 text-right font-semibold text-tertiary">Total</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-tertiary/10">
+              @for (ln of lines; track $index) {
+              <tr>
+                <td class="px-3 py-2 text-secondary">
+                  {{ categoryName(ln) }}
+                  @if (ln.detalle) { <span class="block text-tertiary">{{ ln.detalle }}</span> }
+                </td>
+                <td class="px-3 py-2 text-right text-secondary tabular-nums">S/ {{ ln.importe | number:'1.2-2' }}</td>
+                <td class="px-3 py-2 text-right text-secondary tabular-nums">{{ ln.peopleCount }}</td>
+                <td class="px-3 py-2 text-right text-secondary tabular-nums">{{ ln.days }}</td>
+                <td class="px-3 py-2 text-right font-semibold text-secondary tabular-nums">S/ {{ ln.lineTotal | number:'1.2-2' }}</td>
+              </tr>
+              }
+            </tbody>
+          </table>
+        </div>
+      </div>
+      }
+
+      <!-- Totales / financiamiento -->
+      <div class="bg-background rounded-xl border border-tertiary/15 p-4 space-y-2.5">
+        <div class="flex justify-between items-center">
+          <span class="text-sm text-tertiary">Monto solicitado</span>
+          <span class="text-lg font-bold text-secondary tabular-nums">S/ {{ viaticoAmount | number:'1.2-2' }}</span>
+        </div>
+        @if (viaticoPaidAmount > 0.01) {
+        <div class="flex justify-between items-center text-sm border-t border-tertiary/10 pt-2.5">
+          <span class="text-tertiary">Financiado / depositado</span>
+          <span class="font-semibold text-secondary tabular-nums">S/ {{ viaticoPaidAmount | number:'1.2-2' }}</span>
+        </div>
+        }
+        @if (pendienteDeposito > 0.01) {
+        <div class="flex justify-between items-center text-sm">
+          <span class="text-amber-600">Pendiente de depósito de Contabilidad</span>
+          <span class="font-semibold text-amber-600 tabular-nums">S/ {{ pendienteDeposito | number:'1.2-2' }}</span>
+        </div>
+        }
+      </div>
+
+      <!-- Datos bancarios -->
+      @if (hasBankData) {
+      <div class="grid grid-cols-2 sm:grid-cols-3 gap-x-6 gap-y-3">
+        @if (report.viaticoBankName) {
+        <div>
+          <span class="block text-tertiary uppercase tracking-wide text-[10px] font-semibold">Banco</span>
+          <span class="text-sm text-secondary break-words">{{ report.viaticoBankName }}</span>
+        </div>
+        }
+        @if (report.viaticoAccountNumber) {
+        <div>
+          <span class="block text-tertiary uppercase tracking-wide text-[10px] font-semibold">Cuenta</span>
+          <span class="text-sm text-secondary break-words">{{ report.viaticoAccountNumber }}</span>
+        </div>
+        }
+        @if (report.viaticoCci) {
+        <div>
+          <span class="block text-tertiary uppercase tracking-wide text-[10px] font-semibold">CCI</span>
+          <span class="text-sm text-secondary break-words">{{ report.viaticoCci }}</span>
+        </div>
+        }
+      </div>
+      }
+
+      <!-- Historial de aprobación -->
+      @if (approvalHistory.length > 0) {
+      <div>
+        <p class="text-xs font-semibold text-tertiary uppercase tracking-wider mb-2">Historial</p>
+        <ul class="space-y-1.5">
+          @for (h of approvalHistory; track $index) {
+          <li class="flex items-center justify-between gap-2 text-xs">
+            <span class="text-secondary">{{ approvalActionLabel(h.action) }} <span class="text-tertiary">· Nivel {{ h.level }}</span></span>
+            <span class="text-tertiary shrink-0">{{ h.date ? (h.date | date:'dd/MM/yyyy HH:mm') : '' }}</span>
+          </li>
+          }
+        </ul>
+      </div>
+      }
+    </div>
+
+    <!-- Footer -->
+    <div class="p-6 pt-2 border-t border-tertiary/10 sticky bottom-0 bg-quaternary">
+      <button (click)="close()"
+        class="w-full h-10 rounded-xl text-sm font-semibold text-white bg-secondary hover:bg-secondary/90 transition-colors">
+        Cerrar
+      </button>
+    </div>
+  </div>
+</div>
+}

--- a/src/app/modules/viaticos/viatico-solicitud-detail/viatico-solicitud-detail.component.ts
+++ b/src/app/modules/viaticos/viatico-solicitud-detail/viatico-solicitud-detail.component.ts
@@ -1,0 +1,137 @@
+import { Component, EventEmitter, Input, OnInit, Output, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { CategoriaService } from '../../../services/categoria.service';
+import { IExpenseReport } from '../../../interfaces/expense-report.interface';
+
+const STATUS_LABELS: Record<string, string> = {
+  solicited: 'Solicitada',
+  open: 'Registrando gastos',
+  submitted: 'Enviada',
+  pending_accounting: 'En contabilidad',
+  approved: 'Aprobada',
+  rejected: 'Rechazada',
+  reimbursed: 'Reembolsada',
+  closed: 'Cerrada',
+  cancelled: 'Cancelada',
+  pending_l1: 'En solicitud',
+  pending_l2: 'Aprobada por coordinador',
+  viatico_approved: 'Aprobada',
+  partially_paid: 'Pago parcial',
+  settled: 'Liquidada',
+  returned: 'Saldo devuelto',
+};
+
+const STATUS_COLORS: Record<string, string> = {
+  solicited: 'bg-purple-100 text-purple-800',
+  open: 'bg-blue-100 text-blue-800',
+  submitted: 'bg-yellow-100 text-yellow-800',
+  pending_accounting: 'bg-amber-100 text-amber-800',
+  approved: 'bg-green-100 text-green-800',
+  rejected: 'bg-red-100 text-red-800',
+  reimbursed: 'bg-emerald-100 text-emerald-800',
+  closed: 'bg-gray-100 text-gray-800',
+  cancelled: 'bg-gray-100 text-gray-500',
+  pending_l1: 'bg-yellow-100 text-yellow-800',
+  pending_l2: 'bg-orange-100 text-orange-700',
+  viatico_approved: 'bg-blue-100 text-blue-800',
+  partially_paid: 'bg-amber-100 text-amber-700',
+  settled: 'bg-emerald-100 text-emerald-800',
+};
+
+/**
+ * Popup con el detalle de una SOLICITUD de viático, para coordinador/contabilidad
+ * en las tablas de acciones (Rendiciones y Tesorería). Muestra lo solicitado por el
+ * colaborador (lugar, fechas, líneas por categoría, montos y financiamiento) sin
+ * salir de la vista. El host controla la visibilidad pasando/limpiando `report`.
+ */
+@Component({
+  selector: 'app-viatico-solicitud-detail',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './viatico-solicitud-detail.component.html',
+})
+export class ViaticoSolicitudDetailComponent implements OnInit {
+  private categoriaService = inject(CategoriaService);
+
+  /** Reporte de viático a mostrar. Si es null, el popup no se renderiza. */
+  @Input() report: IExpenseReport | null = null;
+  /** Nombre del colaborador (el host ya suele resolverlo). */
+  @Input() userName = '';
+  /** Nombre del centro de costo (el host ya suele resolverlo). */
+  @Input() projectName = '';
+  @Output() closed = new EventEmitter<void>();
+
+  /** Nombre de categoría por id, para el detalle de líneas. */
+  private categoryNameById = new Map<string, string>();
+  expandedLines = signal<Set<number>>(new Set<number>());
+
+  ngOnInit(): void {
+    this.categoriaService.getAllFlat().subscribe({
+      next: cats => {
+        this.categoryNameById.clear();
+        for (const c of cats ?? []) this.categoryNameById.set(String(c._id), c.name);
+      },
+      error: () => {},
+    });
+  }
+
+  get lines(): any[] {
+    return (this.report as any)?.viaticoLines ?? [];
+  }
+
+  get statusLabel(): string {
+    const s = this.report?.status ?? '';
+    return STATUS_LABELS[s] ?? s;
+  }
+
+  get statusColor(): string {
+    const s = this.report?.status ?? '';
+    return STATUS_COLORS[s] ?? 'bg-gray-100 text-gray-700';
+  }
+
+  get viaticoAmount(): number {
+    return Number((this.report as any)?.viaticoAmount ?? this.report?.budget ?? 0);
+  }
+
+  get viaticoPaidAmount(): number {
+    return Number((this.report as any)?.viaticoPaidAmount ?? 0);
+  }
+
+  get pendienteDeposito(): number {
+    const pend = Math.round((this.viaticoAmount - this.viaticoPaidAmount) * 100) / 100;
+    return pend > 0.01 ? pend : 0;
+  }
+
+  get hasBankData(): boolean {
+    const r = this.report as any;
+    return !!(r?.viaticoBankName || r?.viaticoAccountNumber || r?.viaticoCci);
+  }
+
+  get approvalHistory(): any[] {
+    return (this.report as any)?.viaticoApprovalHistory ?? [];
+  }
+
+  categoryName(line: any): string {
+    const c = line?.categoryId;
+    if (c && typeof c === 'object' && 'name' in c) return (c as { name: string }).name;
+    return this.categoryNameById.get(String(c)) || '—';
+  }
+
+  approvalActionLabel(action: string): string {
+    return action === 'approved' ? 'Aprobó' : action === 'rejected' ? 'Rechazó' : action;
+  }
+
+  toggleLine(index: number): void {
+    const s = new Set(this.expandedLines());
+    s.has(index) ? s.delete(index) : s.add(index);
+    this.expandedLines.set(s);
+  }
+
+  isLineExpanded(index: number): boolean {
+    return this.expandedLines().has(index);
+  }
+
+  close(): void {
+    this.closed.emit();
+  }
+}


### PR DESCRIPTION
…solicitud

- Detalle de viático (mis-rendiciones): Presupuesto muestra viaticoAmount (total) con desglose del financiamiento acotado a lo aplicado y "pendiente de deposito"; no se toca "Saldo Disponible". Modales y PDF usan el presupuesto total.
- Nuevo componente reutilizable viatico-solicitud-detail (popup).
- /rendiciones y /tesoreria: boton "Detalle" de un viatico abre el popup mientras sigue en solicitud (pending_l1/l2/viatico_approved); si ya registra gastos (open/partially_paid y posteriores) navega directo a la rendicion.