### PR TITLE
feat: add dedicated page for accounting entries and update related co…

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -286,6 +286,14 @@ export const routes: Routes = [
         canActivate: [AuthColaboradorGuard],
       },
       {
+        path: 'mis-rendiciones/:id/asientos-contables',
+        loadComponent: () =>
+          import('./modules/mis-rendiciones/asientos-contables/asientos-contables.component').then(
+            (m) => m.AsientosContablesComponent
+          ),
+        canActivate: [AuthColaboradorGuard],
+      },
+      {
         path: 'mi-firma',
         loadComponent: () =>
           import('./modules/firma-digital/firma-digital.component').then(

--- a/src/app/modules/mis-rendiciones/asientos-contables/asientos-contables.component.html
+++ b/src/app/modules/mis-rendiciones/asientos-contables/asientos-contables.component.html
@@ -1,0 +1,174 @@
+<div class="min-h-screen bg-gray-50">
+
+  <!-- Header sticky -->
+  <div class="sticky top-0 z-10 bg-white border-b border-gray-200 shadow-sm">
+    <div class="max-w-5xl mx-auto px-4 sm:px-6 py-3 flex items-center justify-between gap-4">
+      <div class="flex items-center gap-3 min-w-0">
+        <button type="button" (click)="goBack()"
+          class="flex items-center gap-1.5 text-sm font-medium text-gray-500 hover:text-gray-900 transition-colors shrink-0">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-4 h-4">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" />
+          </svg>
+          Rendición
+        </button>
+        <span class="text-gray-200 text-xl font-light">|</span>
+        <h1 class="text-base font-bold text-gray-900 truncate">Asientos contables</h1>
+      </div>
+      @if (!loadingReport()) {
+      <button type="button" (click)="generateAll()"
+        class="px-3 py-1.5 bg-blue-600 text-white text-xs font-semibold rounded-lg hover:bg-blue-700 transition-colors shrink-0">
+        Generar todos
+      </button>
+      }
+    </div>
+  </div>
+
+  <div class="max-w-5xl mx-auto px-4 sm:px-6 py-6">
+    @if (loadingReport()) {
+    <div class="flex items-center justify-center py-16 text-sm text-gray-500">Cargando…</div>
+    } @else {
+
+    <p class="text-sm text-gray-500 mb-5">
+      Se generan en segundo plano y quedan guardados en la nube para descargar cuando quieras.
+    </p>
+
+    @if (globalError()) {
+    <div class="rounded-xl bg-red-50 border border-red-100 px-4 py-3 text-sm text-red-700 mb-5">
+      {{ globalError() }}
+    </div>
+    }
+
+    @if (loadingStatus() && !files().length) {
+    <div class="flex items-center gap-2 text-sm text-gray-500 py-10 justify-center">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 animate-spin">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
+      </svg>
+      Consultando estado…
+    </div>
+    } @else {
+
+    <div class="space-y-5">
+      @for (file of files(); track file.tipo) {
+      <div class="bg-white rounded-2xl border border-gray-100 shadow-sm overflow-hidden">
+
+        <!-- Cabecera de la card -->
+        <div class="px-5 py-4 flex items-center justify-between gap-3 flex-wrap">
+          <div class="min-w-0">
+            <div class="flex items-center gap-2 flex-wrap">
+              <h2 class="text-sm font-semibold text-gray-900">{{ tipoLabel(file.tipo) }}</h2>
+              @switch (file.status) {
+                @case ('ready') {
+                <span class="px-2 py-0.5 rounded-full text-[11px] font-medium"
+                      [class]="file.stale ? 'bg-amber-100 text-amber-700' : 'bg-green-100 text-green-700'">
+                  {{ file.stale ? 'Desactualizado' : 'Listo' }}
+                </span>
+                }
+                @case ('processing') {
+                <span class="px-2 py-0.5 rounded-full text-[11px] font-medium bg-blue-100 text-blue-700 inline-flex items-center gap-1">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-3 h-3 animate-spin">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
+                  </svg>
+                  Generando
+                </span>
+                }
+                @case ('error') {
+                <span class="px-2 py-0.5 rounded-full text-[11px] font-medium bg-red-100 text-red-700">Error</span>
+                }
+                @default {
+                <span class="px-2 py-0.5 rounded-full text-[11px] font-medium bg-gray-100 text-gray-500">Sin generar</span>
+                }
+              }
+            </div>
+            @if (file.status === 'ready') {
+            <p class="text-xs text-gray-500 mt-0.5">{{ file.filename }} · {{ file.asientosCount }} asiento(s)</p>
+            } @else if (file.status === 'processing' && file.url) {
+            <p class="text-xs text-gray-400 mt-0.5">Puedes descargar la versión anterior mientras termina.</p>
+            } @else if (file.status === 'error') {
+            <p class="text-xs text-red-600 mt-0.5">
+              {{ file.errorMessage || 'Error al generar' }}
+              @if (file.url) { <span class="text-gray-400">· la última versión generada sigue disponible</span> }
+            </p>
+            }
+          </div>
+
+          <div class="flex items-center gap-2 shrink-0">
+            @if (file.url) {
+            <button type="button" (click)="download(file)"
+              class="px-3 py-1.5 rounded-lg bg-blue-600 text-white text-xs font-medium hover:bg-blue-700">
+              Descargar
+            </button>
+            }
+            @if (file.status === 'processing') {
+            <span class="px-3 py-1.5 text-xs text-gray-400">Generando…</span>
+            } @else if (file.url) {
+            <button type="button" (click)="generate(file.tipo, true)" [disabled]="isTriggering(file.tipo)"
+              class="px-3 py-1.5 rounded-lg border border-gray-200 text-gray-600 text-xs font-medium hover:bg-gray-50 disabled:opacity-40">
+              {{ isTriggering(file.tipo) ? 'Regenerando…' : 'Regenerar' }}
+            </button>
+            } @else {
+            <button type="button" (click)="generate(file.tipo)" [disabled]="isTriggering(file.tipo)"
+              class="px-3 py-1.5 rounded-lg bg-gray-100 text-gray-700 text-xs font-medium hover:bg-gray-200 disabled:opacity-40">
+              {{ isTriggering(file.tipo) ? 'Generando…' : (file.status === 'error' ? 'Reintentar' : 'Generar') }}
+            </button>
+            }
+          </div>
+        </div>
+
+        <!-- Avisos de configuración -->
+        @if (file.warnings?.length) {
+        <div class="mx-5 mb-4 rounded-xl bg-amber-50 border border-amber-100 px-4 py-3">
+          <p class="text-xs font-medium text-amber-800 mb-1">Avisos de configuración</p>
+          <ul class="space-y-1">
+            @for (w of file.warnings; track w) {
+            <li class="text-xs text-amber-700">⚠ {{ w }}</li>
+            }
+          </ul>
+        </div>
+        }
+
+        <!-- Detalle de descuadres: tabla, no lista apretada -->
+        @if (file.cuadreErrors?.length) {
+        <div class="mx-5 mb-5">
+          <p class="text-xs font-semibold text-red-700 mb-2">
+            Descuadre detectado en {{ file.cuadreErrors!.length }} asiento(s)
+          </p>
+          <div class="border border-red-100 rounded-xl overflow-x-auto">
+            <table class="w-full text-xs">
+              <thead>
+                <tr class="bg-red-50 text-red-800 text-left">
+                  <th class="px-3 py-2 font-medium">Documento</th>
+                  <th class="px-3 py-2 font-medium whitespace-nowrap">Fila(s)</th>
+                  <th class="px-3 py-2 font-medium text-right">Debe</th>
+                  <th class="px-3 py-2 font-medium text-right">Haber</th>
+                  <th class="px-3 py-2 font-medium text-right">Diferencia</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-red-50">
+                @for (e of file.cuadreErrors; track e.relacionado) {
+                <tr class="text-gray-700">
+                  <td class="px-3 py-2">{{ e.documento || ('Asiento #' + e.relacionado) }}</td>
+                  <td class="px-3 py-2 whitespace-nowrap text-gray-500">
+                    @if (e.filaInicio) {
+                      {{ e.filaInicio }}{{ e.filaFin && e.filaFin !== e.filaInicio ? '-' + e.filaFin : '' }}
+                    } @else { — }
+                  </td>
+                  <td class="px-3 py-2 text-right">{{ e.totalDebe }}</td>
+                  <td class="px-3 py-2 text-right">{{ e.totalHaber }}</td>
+                  <td class="px-3 py-2 text-right text-red-600 font-medium">{{ e.diferencia }}</td>
+                </tr>
+                }
+              </tbody>
+            </table>
+          </div>
+          @if (!file.warnings?.length) {
+          <p class="text-xs text-gray-400 mt-2">Revisa los montos del comprobante en esas filas.</p>
+          }
+        </div>
+        }
+      </div>
+      }
+    </div>
+    }
+    }
+  </div>
+</div>

--- a/src/app/modules/mis-rendiciones/asientos-contables/asientos-contables.component.ts
+++ b/src/app/modules/mis-rendiciones/asientos-contables/asientos-contables.component.ts
@@ -1,0 +1,190 @@
+import { Component, OnDestroy, OnInit, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute, Router } from '@angular/router';
+import { ExpenseReportsService } from '../../../services/expense-reports.service';
+import { UserStateService } from '../../../services/user-state.service';
+import { NotificationService } from '../../../services/notification.service';
+import {
+  AccountingEntriesService,
+  AsientoTipo,
+  IAccountingEntryStatus,
+} from '../../../services/accounting-entries.service';
+import { IExpenseReport } from '../../../interfaces/expense-report.interface';
+
+@Component({
+  selector: 'app-asientos-contables',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './asientos-contables.component.html',
+})
+export class AsientosContablesComponent implements OnInit, OnDestroy {
+  private route = inject(ActivatedRoute);
+  private router = inject(Router);
+  private expenseReportsService = inject(ExpenseReportsService);
+  private userStateService = inject(UserStateService);
+  private notificationService = inject(NotificationService);
+  private accountingEntriesService = inject(AccountingEntriesService);
+
+  id: string = this.route.snapshot.params['id'];
+  report = signal<IExpenseReport | null>(null);
+  loadingReport = signal(true);
+
+  files = signal<IAccountingEntryStatus[]>([]);
+  loadingStatus = signal(false);
+  globalError = signal<string | null>(null);
+  triggering = signal<Set<AsientoTipo>>(new Set());
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+
+  private readonly tipoLabels: Record<AsientoTipo, string> = {
+    solicitud: 'Solicitud',
+    compra: 'Compra',
+    aplicacion: 'Aplicación',
+    devolucion: 'Devolución',
+    reembolso: 'Reembolso',
+  };
+
+  tipoLabel(tipo: AsientoTipo): string {
+    return this.tipoLabels[tipo] ?? tipo;
+  }
+
+  get canAccess(): boolean {
+    return this.userStateService.isContabilidad();
+  }
+
+  ngOnInit(): void {
+    if (!this.canAccess) {
+      this.router.navigate(['/mis-rendiciones', this.id, 'detalle']);
+      return;
+    }
+    this.expenseReportsService.findOne(this.id).subscribe({
+      next: (data) => {
+        this.report.set(data);
+        this.loadingReport.set(false);
+        this.fetchStatus();
+      },
+      error: () => {
+        this.loadingReport.set(false);
+        this.globalError.set('No se pudo cargar la rendición.');
+      },
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.clearPoll();
+  }
+
+  goBack(): void {
+    this.router.navigate(['/mis-rendiciones', this.id, 'detalle']);
+  }
+
+  /**
+   * Tipos de asiento que pueden producir salida para esta rendición.
+   * Evita pedir al backend trabajo innecesario (devolución/reembolso solo
+   * aplican si el tipo de liquidación coincide). `solicitud` se mantiene
+   * siempre porque depende de anticipos no visibles en este modelo; el
+   * backend la descarta si no hay anticipos.
+   */
+  private applicableTipos(): AsientoTipo[] {
+    const report = this.report();
+    const tipos: AsientoTipo[] = ['solicitud'];
+    if (report?.expenseIds?.length) {
+      tipos.push('compra', 'aplicacion');
+    }
+    const settlementType = report?.settlement?.type;
+    if (settlementType === 'devolucion') tipos.push('devolucion');
+    if (settlementType === 'reembolso') tipos.push('reembolso');
+    return tipos;
+  }
+
+  isTriggering(tipo: AsientoTipo): boolean {
+    return this.triggering().has(tipo);
+  }
+
+  private clearPoll(): void {
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+  }
+
+  fetchStatus(): void {
+    this.loadingStatus.set(true);
+    this.globalError.set(null);
+    this.accountingEntriesService.getStatus(this.id, this.applicableTipos()).subscribe({
+      next: (res) => {
+        this.loadingStatus.set(false);
+        this.files.set(res?.files ?? []);
+        this.syncPolling();
+      },
+      error: (err) => {
+        this.loadingStatus.set(false);
+        this.globalError.set(
+          err?.error?.message || err?.message || 'Error al consultar los asientos.'
+        );
+      },
+    });
+  }
+
+  /** Mientras haya algún tipo en 'processing', consulta el estado cada 3s. */
+  private syncPolling(): void {
+    const hasProcessing = this.files().some((f) => f.status === 'processing');
+    if (hasProcessing && !this.pollTimer) {
+      this.pollTimer = setInterval(() => this.fetchStatus(), 3000);
+    } else if (!hasProcessing) {
+      this.clearPoll();
+    }
+  }
+
+  private mergeStatus(updated: IAccountingEntryStatus[]): void {
+    const byTipo = new Map(updated.map((f) => [f.tipo, f]));
+    this.files.set(this.files().map((f) => byTipo.get(f.tipo) ?? f));
+  }
+
+  /** Genera (o regenera, con `force`) un único tipo de asiento en 2do plano. */
+  generate(tipo: AsientoTipo, force = false): void {
+    if (this.isTriggering(tipo)) return;
+    const triggering = new Set(this.triggering());
+    triggering.add(tipo);
+    this.triggering.set(triggering);
+    this.accountingEntriesService.triggerGenerate(this.id, [tipo], force).subscribe({
+      next: (res) => {
+        const t = new Set(this.triggering());
+        t.delete(tipo);
+        this.triggering.set(t);
+        this.mergeStatus(res?.files ?? []);
+        this.syncPolling();
+      },
+      error: (err) => {
+        const t = new Set(this.triggering());
+        t.delete(tipo);
+        this.triggering.set(t);
+        this.notificationService.show(
+          err?.error?.message || err?.message || 'Error al generar el asiento.',
+          'error'
+        );
+      },
+    });
+  }
+
+  /** Genera todos los tipos aplicables que aún no estén listos y al día. */
+  generateAll(): void {
+    const tipos = this.applicableTipos();
+    if (!tipos.length) return;
+    this.accountingEntriesService.triggerGenerate(this.id, tipos).subscribe({
+      next: (res) => {
+        this.mergeStatus(res?.files ?? []);
+        this.syncPolling();
+      },
+      error: (err) => {
+        this.notificationService.show(
+          err?.error?.message || err?.message || 'Error al generar los asientos.',
+          'error'
+        );
+      },
+    });
+  }
+
+  download(file: IAccountingEntryStatus): void {
+    this.accountingEntriesService.download(this.id, file);
+  }
+}

--- a/src/app/modules/mis-rendiciones/rendicion-detail/rendicion-detail.component.html
+++ b/src/app/modules/mis-rendiciones/rendicion-detail/rendicion-detail.component.html
@@ -129,20 +129,23 @@
           </svg>
         </app-button>
         @if (canDownloadAsientos) {
-        <app-button
-          label="Asientos contables"
-          variant="secondary"
-          size="sm"
-          [fullWidth]="false"
-          [loading]="downloadingAsientos"
-          loadingLabel="Generando…"
-          [disabled]="downloadingAsientos"
-          (clicked)="downloadAsientos()"
-        >
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 shrink-0">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 9.776c.112-.017.227-.026.344-.026h15.812c.117 0 .232.009.344.026m-16.5 0a2.25 2.25 0 0 0-1.883 2.542l.857 6a2.25 2.25 0 0 0 2.227 1.932H19.05a2.25 2.25 0 0 0 2.227-1.932l.857-6a2.25 2.25 0 0 0-1.883-2.542m-16.5 0V6A2.25 2.25 0 0 1 6 3.75h3.879a1.5 1.5 0 0 1 1.06.44l2.122 2.12a1.5 1.5 0 0 0 1.06.44H18A2.25 2.25 0 0 1 20.25 9v.776" />
-          </svg>
-        </app-button>
+        <div class="relative inline-block">
+          <app-button
+            label="Asientos contables"
+            variant="secondary"
+            size="sm"
+            [fullWidth]="false"
+            (clicked)="goToAsientosContables()"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 shrink-0">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 9.776c.112-.017.227-.026.344-.026h15.812c.117 0 .232.009.344.026m-16.5 0a2.25 2.25 0 0 0-1.883 2.542l.857 6a2.25 2.25 0 0 0 2.227 1.932H19.05a2.25 2.25 0 0 0 2.227-1.932l.857-6a2.25 2.25 0 0 0-1.883-2.542m-16.5 0V6A2.25 2.25 0 0 1 6 3.75h3.879a1.5 1.5 0 0 1 1.06.44l2.122 2.12a1.5 1.5 0 0 0 1.06.44H18A2.25 2.25 0 0 1 20.25 9v.776" />
+            </svg>
+          </app-button>
+          @if (asientosBadgeClass) {
+          <span class="absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full ring-2 ring-white pointer-events-none"
+                [class]="asientosBadgeClass"></span>
+          }
+        </div>
         }
       </div>
 
@@ -3308,85 +3311,7 @@
 </div>
 }
 
-<!-- Modal: Progreso de generación de asientos contables -->
-@if (asientosModalOpen()) {
-<div class="fixed inset-0 z-[70] flex items-center justify-center p-4"
-     (click)="closeAsientosModal()" role="dialog" aria-modal="true">
-  <div class="absolute inset-0 bg-black/50 backdrop-blur-sm"></div>
-  <div class="relative bg-white rounded-2xl shadow-xl w-full max-w-md overflow-hidden"
-       (click)="$event.stopPropagation()">
-    <!-- Cabecera -->
-    <div class="px-6 pt-6 pb-4 border-b border-gray-100 flex items-center gap-3">
-      <div class="flex-shrink-0 w-10 h-10 rounded-full flex items-center justify-center"
-           [class]="asientosError() ? 'bg-red-100' : asientosDone() ? 'bg-green-100' : 'bg-blue-100'">
-        @if (asientosError()) {
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor" class="w-5 h-5 text-red-600">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z" />
-        </svg>
-        } @else if (asientosDone()) {
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5 text-green-600">
-          <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
-        </svg>
-        } @else {
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-blue-600 animate-spin">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
-        </svg>
-        }
-      </div>
-      <div>
-        <h3 class="text-base font-semibold text-gray-900">
-          {{ asientosError() ? 'No se pudieron generar' : asientosDone() ? 'Asientos generados' : 'Generando asientos contables' }}
-        </h3>
-        <p class="text-xs text-gray-500">
-          {{ asientosError() ? 'Revisa el detalle e inténtalo de nuevo' : asientosDone() ? 'La descarga comenzará en un momento' : 'Esto puede tardar unos segundos' }}
-        </p>
-      </div>
-    </div>
+<!-- Los asientos contables ahora tienen su propia página dedicada:
+     ver goToAsientosContables() y /mis-rendiciones/:id/asientos-contables -->
 
-    <!-- Cuerpo -->
-    <div class="px-6 py-5">
-      @if (asientosError()) {
-      <div class="rounded-xl bg-red-50 border border-red-100 px-4 py-3 text-sm text-red-700">
-        {{ asientosError() }}
-      </div>
-      } @else {
-      <ol class="space-y-3">
-        @for (step of asientosSteps(); track step.label) {
-        <li class="flex items-center gap-3">
-          <span class="flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center"
-                [class]="step.status === 'done' ? 'bg-green-100' : step.status === 'active' ? 'bg-blue-100' : 'bg-gray-100'">
-            @if (step.status === 'done') {
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" class="w-3.5 h-3.5 text-green-600">
-              <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
-            </svg>
-            } @else if (step.status === 'active') {
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-3.5 h-3.5 text-blue-600 animate-spin">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
-            </svg>
-            } @else {
-            <span class="w-1.5 h-1.5 rounded-full bg-gray-400"></span>
-            }
-          </span>
-          <span class="text-sm"
-                [class]="step.status === 'pending' ? 'text-gray-400' : 'text-gray-800 font-medium'">
-            {{ step.label }}
-          </span>
-        </li>
-        }
-      </ol>
-      }
-    </div>
-
-    <!-- Pie: solo botón de cerrar cuando hay error (durante la carga no se puede cerrar) -->
-    @if (asientosError()) {
-    <div class="px-6 pb-6">
-      <button type="button" (click)="closeAsientosModal()"
-        class="w-full py-2 bg-gray-100 text-gray-700 rounded-xl text-sm font-medium hover:bg-gray-200">
-        Cerrar
-      </button>
-    </div>
-    }
-  </div>
-</div>
-}
 

--- a/src/app/modules/mis-rendiciones/rendicion-detail/rendicion-detail.component.ts
+++ b/src/app/modules/mis-rendiciones/rendicion-detail/rendicion-detail.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, inject, signal, computed, HostListener, WritableSignal } from '@angular/core';
+import { Component, OnInit, inject, signal, computed, HostListener, WritableSignal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
@@ -12,7 +12,7 @@ import { InvoicesService } from '../../invoices/services/invoices.service';
 import { UploadService } from '../../../services/upload.service';
 import {
   AccountingEntriesService,
-  IGeneratedFile,
+  IAccountingEntryStatus,
   AsientoTipo,
 } from '../../../services/accounting-entries.service';
 import { IExpenseReport, IReportFinancingSaldo } from '../../../interfaces/expense-report.interface';
@@ -36,12 +36,6 @@ import {
   resolveExpenseFechaEmision,
 } from '../../../utils/fecha-emision.util';
 
-/** Paso del proceso de generación de asientos, para el modal de progreso. */
-interface AsientoStep {
-  label: string;
-  status: 'pending' | 'active' | 'done';
-}
-
 @Component({
   selector: 'app-rendicion-detail',
   standalone: true,
@@ -55,7 +49,7 @@ interface AsientoStep {
   templateUrl: './rendicion-detail.component.html',
   styleUrls: ['./rendicion-detail.component.scss']
 })
-export class RendicionDetailComponent implements OnInit, OnDestroy {
+export class RendicionDetailComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private expenseReportsService = inject(ExpenseReportsService);
@@ -341,6 +335,7 @@ export class RendicionDetailComponent implements OnInit, OnDestroy {
         this.updateDocCounts(data);
         this.isLoading = false;
         this.loadExpensesPage(1);
+        if (this.canDownloadAsientos) this.fetchAsientosStatus();
         // Auto-cierre: viáticos equilibrados que quedaron en 'approved' por datos stale.
         if (
           (data as any)?.type === 'viatico' &&
@@ -464,71 +459,29 @@ export class RendicionDetailComponent implements OnInit, OnDestroy {
       || (this.userStateService.isCoordinador() && this.userStateService.hasModulePermission('rendiciones'));
   }
 
-  // --- Descarga de asientos contables (solo Contabilidad) ---
-  downloadingAsientos = false;
+  // --- Asientos contables (solo Contabilidad): indicador + navegación a página dedicada ---
+  // El detalle completo (generar/regenerar/descargar, descuadres, avisos) vive en su propia
+  // página (`/mis-rendiciones/:id/asientos-contables`): con hasta 25+ descuadres por tipo,
+  // un modal quedaba demasiado apretado para mostrar esa información con claridad.
+  asientosFiles = signal<IAccountingEntryStatus[]>([]);
 
-  // Modal de progreso paso a paso de la generación de asientos.
-  asientosModalOpen = signal(false);
-  asientosSteps = signal<AsientoStep[]>([]);
-  asientosError = signal<string | null>(null);
-  asientosDone = signal(false);
-  private asientosStepTimer: ReturnType<typeof setInterval> | null = null;
-
-  /** Pasos mostrados al usuario (reflejan el proceso real del backend). */
-  private asientosStepLabels(): string[] {
-    return [
-      'Leyendo datos de la rendición',
-      'Verificando caché de asientos',
-      'Clasificando cuentas contables con IA',
-      'Calculando tipo de cambio',
-      'Generando archivos Excel (Contanet)',
-    ];
-  }
-
-  /** Solo el rol Contabilidad puede descargar los asientos contables. */
+  /** Solo el rol Contabilidad puede generar/descargar los asientos contables. */
   get canDownloadAsientos(): boolean {
     return this.userStateService.isContabilidad();
   }
 
-  private clearAsientosTimer(): void {
-    if (this.asientosStepTimer) {
-      clearInterval(this.asientosStepTimer);
-      this.asientosStepTimer = null;
-    }
-  }
-
   /**
-   * Avanza el paso activo. No pasa del último automáticamente: ese se marca
-   * como completado solo cuando el backend responde.
+   * Color del indicador en el botón "Asientos contables", para que el estado
+   * se vea sin necesidad de entrar a la página de detalle.
    */
-  private advanceAsientoStep(): void {
-    const steps = this.asientosSteps();
-    const activeIdx = steps.findIndex((s) => s.status === 'active');
-    if (activeIdx === -1 || activeIdx >= steps.length - 1) return;
-    this.asientosSteps.set(
-      steps.map((s, i) => {
-        if (i === activeIdx) return { ...s, status: 'done' };
-        if (i === activeIdx + 1) return { ...s, status: 'active' };
-        return s;
-      })
-    );
-  }
-
-  private markAllAsientoStepsDone(): void {
-    this.asientosSteps.set(
-      this.asientosSteps().map((s) => ({ ...s, status: 'done' }))
-    );
-  }
-
-  /** Cierra el modal de asientos (solo si ya no está cargando). */
-  closeAsientosModal(): void {
-    if (this.downloadingAsientos) return;
-    this.clearAsientosTimer();
-    this.asientosModalOpen.set(false);
-  }
-
-  ngOnDestroy(): void {
-    this.clearAsientosTimer();
+  get asientosBadgeClass(): string | null {
+    const files = this.asientosFiles();
+    if (!files.length) return null;
+    if (files.some((f) => f.status === 'processing')) return 'bg-blue-500 animate-pulse';
+    if (files.some((f) => f.status === 'error')) return 'bg-red-500';
+    if (files.some((f) => f.status === 'ready' && f.stale)) return 'bg-amber-500';
+    if (files.some((f) => f.status === 'ready')) return 'bg-green-500';
+    return null;
   }
 
   /**
@@ -549,78 +502,21 @@ export class RendicionDetailComponent implements OnInit, OnDestroy {
     return tipos;
   }
 
-  downloadAsientos(): void {
-    if (!this.report?._id || this.downloadingAsientos) return;
-    this.downloadingAsientos = true;
-    this.asientosError.set(null);
-    this.asientosDone.set(false);
-    this.asientosSteps.set(
-      this.asientosStepLabels().map((label, i) => ({
-        label,
-        status: i === 0 ? 'active' : 'pending',
-      }))
-    );
-    this.asientosModalOpen.set(true);
-    this.clearAsientosTimer();
-    this.asientosStepTimer = setInterval(() => this.advanceAsientoStep(), 850);
-
+  /** Consulta el estado una sola vez, solo para pintar el indicador del botón. */
+  private fetchAsientosStatus(): void {
+    if (!this.report?._id) return;
     this.accountingEntriesService
-      .generate(this.report._id, this.applicableAsientoTipos())
+      .getStatus(this.report._id, this.applicableAsientoTipos())
       .subscribe({
-        next: (res: { files: IGeneratedFile[] }) => {
-          this.clearAsientosTimer();
-          this.downloadingAsientos = false;
-          this.markAllAsientoStepsDone();
-          const files = res?.files ?? [];
-          if (!files.length) {
-            this.asientosError.set(
-              'No hay asientos que generar para esta rendición.'
-            );
-            return;
-          }
-          this.asientosDone.set(true);
-          for (const file of files) {
-            this.accountingEntriesService.downloadBase64(file);
-          }
-          const conErrores = files.filter((f) => f.cuadreErrors?.length);
-          // Breve confirmación visual antes de cerrar el modal.
-          setTimeout(() => {
-            this.asientosModalOpen.set(false);
-            if (conErrores.length) {
-              this.notificationService.show(
-                `Asientos descargados. Atención: ${conErrores
-                  .map((f) => f.tipo)
-                  .join(', ')} con descuadre. Revisa el desglose contable.`,
-                'error'
-              );
-            } else {
-              this.notificationService.show(
-                `Asientos descargados (${files.length} archivo(s)).`,
-                'success'
-              );
-            }
-          }, 1000);
-        },
-        error: (err) => {
-          this.clearAsientosTimer();
-          this.downloadingAsientos = false;
-          console.group('[asientos] ERROR detalle');
-          console.log('status:', err?.status);
-          console.log('statusText:', err?.statusText);
-          console.log('message:', err?.message);
-          console.log('error.message:', err?.error?.message);
-          console.log('error (raw):', err?.error);
-          console.log('¿status 0?', err?.status === 0, '→ probable timeout nginx o CORS');
-          console.log('¿status 408?', err?.status === 408, '→ timeout NestJS (>295 s)');
-          console.log('¿status 403?', err?.status === 403, '→ rol no autorizado en backend');
-          console.groupEnd();
-          this.asientosError.set(
-            err?.error?.message ||
-              err?.message ||
-              'Error desconocido al generar los asientos.'
-          );
-        },
+        next: (res) => this.asientosFiles.set(res?.files ?? []),
+        error: () => {},
       });
+  }
+
+  /** Navega a la página dedicada de asientos contables. */
+  goToAsientosContables(): void {
+    if (!this.report?._id) return;
+    this.router.navigate(['/mis-rendiciones', this.report._id, 'asientos-contables']);
   }
 
   get canApproveExpenses(): boolean {

--- a/src/app/services/accounting-entries.service.ts
+++ b/src/app/services/accounting-entries.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { tap } from 'rxjs/operators';
 import { environment } from '../../environments/environment';
 
 export type AsientoTipo =
@@ -11,19 +10,34 @@ export type AsientoTipo =
   | 'devolucion'
   | 'reembolso';
 
+export type AccountingEntriesStatus = 'none' | 'processing' | 'ready' | 'error';
+
 export interface ICuadreError {
   relacionado: number;
   totalDebe: number;
   totalHaber: number;
   diferencia: number;
+  /** Fila de Excel (1-indexed) de la primera/última línea de este asiento en el .xlsx generado. */
+  filaInicio?: number;
+  filaFin?: number;
+  /** Descripción legible del comprobante/anticipo (razón social + serie-número, o glosa). */
+  documento?: string;
 }
 
-export interface IGeneratedFile {
-  filename: string;
-  base64: string;
+export interface IAccountingEntryStatus {
   tipo: AsientoTipo;
-  asientosCount: number;
-  cuadreErrors: ICuadreError[];
+  status: AccountingEntriesStatus;
+  filename?: string;
+  /** URL firmada de S3, válida por pocos minutos. Solo presente si hay un archivo listo. */
+  url?: string;
+  asientosCount?: number;
+  cuadreErrors?: ICuadreError[];
+  /** Avisos de configuración (ej. categoría sin cuenta 9X) detectados al generar. */
+  warnings?: string[];
+  errorMessage?: string;
+  /** El archivo listo ya no refleja el estado actual de la rendición. */
+  stale?: boolean;
+  completedAt?: string;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -31,39 +45,66 @@ export class AccountingEntriesService {
   private http = inject(HttpClient);
   private url = `${environment.api}/accounting-entries`;
 
-  generate(
+  /** Estado actual de los asientos (no dispara generación). Usar para pintar la UI y para polling. */
+  getStatus(
     reportId: string,
     tipos?: AsientoTipo[]
-  ): Observable<{ files: IGeneratedFile[] }> {
+  ): Observable<{ files: IAccountingEntryStatus[] }> {
     let params = new HttpParams();
     if (tipos?.length) params = params.set('tipos', tipos.join(','));
-    const fullUrl = `${this.url}/${reportId}?tipos=${tipos?.join(',') ?? ''}`;
-    const t0 = Date.now();
-    console.log('[asientos] REQUEST →', fullUrl);
-    return this.http.get<{ files: IGeneratedFile[] }>(`${this.url}/${reportId}`, { params }).pipe(
-      tap({
-        next: (res) => console.log(`[asientos] RESPONSE OK — ${((Date.now() - t0) / 1000).toFixed(1)}s — ${res?.files?.length ?? 0} archivo(s)`),
-        error: (err) => console.error(`[asientos] RESPONSE ERROR — ${((Date.now() - t0) / 1000).toFixed(1)}s — status=${err?.status}`, err),
-      })
+    return this.http.get<{ files: IAccountingEntryStatus[] }>(
+      `${this.url}/${reportId}`,
+      { params }
     );
   }
 
-  clearCache(reportId: string): Observable<{ deleted: number }> {
-    return this.http.delete<{ deleted: number }>(`${this.url}/cache/${reportId}`);
+  /** Dispara la generación en segundo plano. Responde de inmediato con el estado resultante. */
+  triggerGenerate(
+    reportId: string,
+    tipos?: AsientoTipo[],
+    force = false
+  ): Observable<{ files: IAccountingEntryStatus[] }> {
+    let params = new HttpParams();
+    if (tipos?.length) params = params.set('tipos', tipos.join(','));
+    if (force) params = params.set('force', 'true');
+    return this.http.post<{ files: IAccountingEntryStatus[] }>(
+      `${this.url}/${reportId}/generate`,
+      null,
+      { params }
+    );
   }
 
-  downloadBase64(file: IGeneratedFile): void {
-    const bytes = atob(file.base64);
-    const buffer = new Uint8Array(bytes.length);
-    for (let i = 0; i < bytes.length; i++) buffer[i] = bytes.charCodeAt(i);
-    const blob = new Blob([buffer], {
-      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-    });
-    const url = URL.createObjectURL(blob);
+  /**
+   * Descarga un archivo forzando el guardado (S3 responde con
+   * Content-Disposition: attachment). Se usa un <a> sintético en vez de
+   * `window.open` porque no abre pestaña nueva y no dispara el bloqueador
+   * de pop-ups, incluso si la URL se obtuvo justo antes vía una llamada async.
+   */
+  private triggerDownload(url: string, filename?: string): void {
     const a = document.createElement('a');
     a.href = url;
-    a.download = file.filename;
+    if (filename) a.download = filename;
+    a.rel = 'noopener';
+    document.body.appendChild(a);
     a.click();
-    URL.revokeObjectURL(url);
+    a.remove();
+  }
+
+  /**
+   * Descarga un archivo listo. Las URLs firmadas expiran a los pocos minutos
+   * (ver `getPresignedDownloadUrl` en el backend), así que primero se pide
+   * una fresca en vez de reutilizar la que ya estaba en pantalla — si el
+   * usuario dejó el modal abierto un rato, la URL cacheada podría haber vencido.
+   */
+  download(reportId: string, file: IAccountingEntryStatus): void {
+    if (!file.url) return;
+    this.getStatus(reportId, [file.tipo]).subscribe({
+      next: (res) => {
+        const fresh = res?.files?.[0];
+        if (fresh?.url) this.triggerDownload(fresh.url, fresh.filename);
+        else this.triggerDownload(file.url!, file.filename);
+      },
+      error: () => this.triggerDownload(file.url!, file.filename),
+    });
   }
 }


### PR DESCRIPTION
…mponents

- Added a new route for accounting entries under 'mis-rendiciones/:id/asientos-contables'.
- Created AsientosContablesComponent to handle the display and management of accounting entries.
- Updated RendicionDetailComponent to navigate to the new accounting entries page.
- Refactored the download functionality to support direct navigation instead of modal.
- Removed the modal for generating accounting entries and replaced it with a dedicated UI.
- Enhanced the accounting entries service to support fetching and generating entries.