### PR TITLE
fix(centros-de-costo): perfil de categoria obligatorio en el formulario

### DIFF
--- a/src/app/modules/centros-de-costo/form/centros-de-costo-form.component.html
+++ b/src/app/modules/centros-de-costo/form/centros-de-costo-form.component.html
@@ -68,17 +68,20 @@
       <!-- Perfil de Categoría -->
       <div class="flex flex-col gap-1.5">
         <label class="text-xs font-semibold text-tertiary uppercase tracking-wider">
-          Perfil de Categoría <span class="text-tertiary/60 font-normal normal-case">(opcional)</span>
+          Perfil de Categoría <span class="text-primary">*</span>
         </label>
         <select
           [(ngModel)]="form.categoryGroupId"
           class="h-[42px] px-3 rounded-xl border border-tertiary/30 bg-background text-sm text-secondary focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary transition-all"
         >
-          <option value="">Sin perfil</option>
+          <option value="" disabled>Seleccione un perfil...</option>
           @for (p of perfiles; track p._id) {
           <option [value]="p._id">{{ p.name }}</option>
           }
         </select>
+        <p class="text-xs text-tertiary/70">
+          Obligatorio: el colaborador solo verá este centro de costo si tiene un perfil asignado.
+        </p>
       </div>
 
       <!-- Mapeo contable (asientos Contanet) -->

--- a/src/app/modules/centros-de-costo/form/centros-de-costo-form.component.ts
+++ b/src/app/modules/centros-de-costo/form/centros-de-costo-form.component.ts
@@ -113,6 +113,10 @@ export class CentrosDeCostoFormComponent implements OnInit {
       this.notification.show('El nombre es obligatorio', 'error');
       return;
     }
+    if (!this.form.categoryGroupId) {
+      this.notification.show('El perfil de categoría es obligatorio', 'error');
+      return;
+    }
     this.saving = true;
     const companyId = this.userStateService.getUser()?.companyId || '';
     const payload: Partial<IProject> = {


### PR DESCRIPTION
El colaborador no ve un centro de costo sin perfil asignado, asi que el perfil pasa a ser obligatorio al crear/editar.

- select marcado obligatorio (*, opcion placeholder disabled) + nota
- validacion en save()