### PR TITLE
feat(rendiciones): filtros buscables, filtro de estado y ordenamiento

### DIFF
--- a/src/app/design-system/project-select/project-select.component.ts
+++ b/src/app/design-system/project-select/project-select.component.ts
@@ -132,10 +132,19 @@ export class ProjectSelectComponent implements ControlValueAccessor, OnDestroy {
     // Abre hacia arriba si abajo hay poco espacio y arriba hay más.
     const dropUp = spaceBelow < 240 && spaceAbove > spaceBelow;
     const maxHeight = Math.min(360, Math.max(160, dropUp ? spaceAbove : spaceBelow));
+    // El panel es al menos tan ancho como el disparador, con un mínimo cómodo para leer
+    // etiquetas largas (código — nombre) aunque el filtro viva en una columna angosta.
+    // Se recorta al viewport y se realinea a la derecha si se desbordaría.
+    const viewportWidth = document.documentElement.clientWidth;
+    const width = Math.min(Math.max(rect.width, 320), viewportWidth - margin * 2);
+    let left = rect.left;
+    if (left + width > viewportWidth - margin) {
+      left = Math.max(margin, viewportWidth - margin - width);
+    }
     this.panelPos.set({
       top: dropUp ? rect.top : rect.bottom,
-      left: rect.left,
-      width: rect.width,
+      left,
+      width,
       maxHeight,
       dropUp,
     });

--- a/src/app/design-system/worker-select/worker-select.component.html
+++ b/src/app/design-system/worker-select/worker-select.component.html
@@ -53,6 +53,18 @@
 
     <!-- Opciones -->
     <ul class="flex-1 overflow-y-auto py-1">
+      @if (allowEmpty()) {
+      <li>
+        <button
+          type="button"
+          (click)="clear()"
+          class="w-full text-left px-3.5 py-2 text-sm text-gray-500 hover:bg-gray-50"
+          [ngClass]="{ 'bg-gray-50': !selectedId() }"
+        >
+          {{ emptyLabel() }}
+        </button>
+      </li>
+      }
       @for (w of filteredWorkers(); track w._id) {
       <li>
         <button

--- a/src/app/design-system/worker-select/worker-select.component.ts
+++ b/src/app/design-system/worker-select/worker-select.component.ts
@@ -47,6 +47,10 @@ export class WorkerSelectComponent implements ControlValueAccessor, OnDestroy {
   placeholder = input<string>('Seleccione un trabajador…');
   /** Marca visual de error (borde rojo). */
   invalid = input<boolean>(false);
+  /** Permite limpiar la selección (muestra una opción para no filtrar). */
+  allowEmpty = input<boolean>(false);
+  /** Etiqueta de la opción vacía cuando `allowEmpty` es true. */
+  emptyLabel = input<string>('Sin asignar');
   /** Clases extra para el botón disparador. */
   triggerClass = input<string>('');
 
@@ -131,10 +135,19 @@ export class WorkerSelectComponent implements ControlValueAccessor, OnDestroy {
     const spaceAbove = rect.top - margin;
     const dropUp = spaceBelow < 240 && spaceAbove > spaceBelow;
     const maxHeight = Math.min(360, Math.max(160, dropUp ? spaceAbove : spaceBelow));
+    // El panel es al menos tan ancho como el disparador, con un mínimo cómodo para leer
+    // etiquetas largas (nombre + correo) aunque el filtro viva en una columna angosta.
+    // Se recorta al viewport y se realinea a la derecha si se desbordaría.
+    const viewportWidth = document.documentElement.clientWidth;
+    const width = Math.min(Math.max(rect.width, 320), viewportWidth - margin * 2);
+    let left = rect.left;
+    if (left + width > viewportWidth - margin) {
+      left = Math.max(margin, viewportWidth - margin - width);
+    }
     this.panelPos.set({
       top: dropUp ? rect.top : rect.bottom,
-      left: rect.left,
-      width: rect.width,
+      left,
+      width,
       maxHeight,
       dropUp,
     });
@@ -148,6 +161,12 @@ export class WorkerSelectComponent implements ControlValueAccessor, OnDestroy {
   pick(w: WorkerOption): void {
     this.selectedId.set(w._id ?? '');
     this.onChange(this.selectedId());
+    this.close();
+  }
+
+  clear(): void {
+    this.selectedId.set('');
+    this.onChange('');
     this.close();
   }
 

--- a/src/app/modules/admin-users/rendiciones-admin/rendiciones-admin.component.html
+++ b/src/app/modules/admin-users/rendiciones-admin/rendiciones-admin.component.html
@@ -20,34 +20,47 @@
 
   <!-- Filters -->
   <div class="bg-quaternary rounded-2xl border border-tertiary/20 shadow-soft p-5 mb-6">
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
 
-      <!-- Usuario -->
+      <!-- Colaborador (buscable / tipeable) -->
       <div>
         <label class="block text-xs font-medium text-tertiary mb-1">Colaborador</label>
-        <select
+        <app-worker-select
           [(ngModel)]="filterUserId"
           (ngModelChange)="applyFilters()"
-          class="w-full px-3 py-2 text-sm border border-tertiary/30 rounded-xl bg-background text-secondary focus:outline-none focus:ring-2 focus:ring-primary/30"
-        >
-          <option value="">Todos</option>
-          @for (user of users; track user._id) {
-          <option [value]="user._id">{{ user.name }}</option>
-          }
-        </select>
+          [workers]="users"
+          [allowEmpty]="true"
+          emptyLabel="Todos"
+          placeholder="Todos"
+          triggerClass="!bg-background !border-tertiary/30 !py-2"
+        />
       </div>
 
-      <!-- Proyecto / Centro de costo -->
+      <!-- Centro de costo (buscable / tipeable) -->
       <div>
         <label class="block text-xs font-medium text-tertiary mb-1">Centro de Costo</label>
-        <select
+        <app-project-select
           [(ngModel)]="filterProjectId"
+          (ngModelChange)="applyFilters()"
+          [projects]="projects"
+          [allowEmpty]="true"
+          emptyLabel="Todos"
+          placeholder="Todos"
+          triggerClass="!bg-background !border-tertiary/30 !py-2"
+        />
+      </div>
+
+      <!-- Estado -->
+      <div>
+        <label class="block text-xs font-medium text-tertiary mb-1">Estado</label>
+        <select
+          [(ngModel)]="filterStatus"
           (ngModelChange)="applyFilters()"
           class="w-full px-3 py-2 text-sm border border-tertiary/30 rounded-xl bg-background text-secondary focus:outline-none focus:ring-2 focus:ring-primary/30"
         >
           <option value="">Todos</option>
-          @for (project of projects; track project._id) {
-          <option [value]="project._id">{{ project.name }}</option>
+          @for (s of statusOptions; track s.value) {
+          <option [value]="s.value">{{ s.label }}</option>
           }
         </select>
       </div>
@@ -72,6 +85,21 @@
           (ngModelChange)="applyFilters()"
           class="w-full px-3 py-2 text-sm border border-tertiary/30 rounded-xl bg-background text-secondary focus:outline-none focus:ring-2 focus:ring-primary/30"
         />
+      </div>
+
+      <!-- Ordenar -->
+      <div>
+        <label class="block text-xs font-medium text-tertiary mb-1">Ordenar por</label>
+        <select
+          [(ngModel)]="sortBy"
+          (ngModelChange)="applyFilters()"
+          class="w-full px-3 py-2 text-sm border border-tertiary/30 rounded-xl bg-background text-secondary focus:outline-none focus:ring-2 focus:ring-primary/30"
+        >
+          <option value="date_desc">Fecha (reciente primero)</option>
+          <option value="date_asc">Fecha (antigua primero)</option>
+          <option value="amount_desc">Monto (mayor a menor)</option>
+          <option value="amount_asc">Monto (menor a mayor)</option>
+        </select>
       </div>
 
     </div>

--- a/src/app/modules/admin-users/rendiciones-admin/rendiciones-admin.component.ts
+++ b/src/app/modules/admin-users/rendiciones-admin/rendiciones-admin.component.ts
@@ -15,6 +15,8 @@ import { IAdvance, ADVANCE_STATUS_LABELS, ADVANCE_STATUS_COLORS } from '../../..
 import { IUserResponse } from '../../../interfaces/user.interface';
 import { IProject } from '../../invoices/interfaces/project.interface';
 import { ViaticoSolicitudDetailComponent } from '../../viaticos/viatico-solicitud-detail/viatico-solicitud-detail.component';
+import { WorkerSelectComponent } from '../../../design-system/worker-select/worker-select.component';
+import { ProjectSelectComponent } from '../../../design-system/project-select/project-select.component';
 
 const REPORT_STATUS_LABELS: Record<string, string> = {
   // Rendición normal
@@ -77,7 +79,7 @@ export type UnifiedRendicionItem = {
 @Component({
   selector: 'app-rendiciones-admin',
   standalone: true,
-  imports: [CommonModule, FormsModule, ReactiveFormsModule, RouterModule, ViaticoSolicitudDetailComponent],
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, RouterModule, ViaticoSolicitudDetailComponent, WorkerSelectComponent, ProjectSelectComponent],
   templateUrl: './rendiciones-admin.component.html',
 })
 export class RendicionesAdminComponent implements OnInit {
@@ -118,8 +120,13 @@ export class RendicionesAdminComponent implements OnInit {
 
   filterUserId = '';
   filterProjectId = '';
+  filterStatus = '';
   filterDateFrom = '';
   filterDateTo = '';
+  sortBy: 'date_desc' | 'date_asc' | 'amount_desc' | 'amount_asc' = 'date_desc';
+
+  /** Estados presentes en los datos (para el <select> de Estado); se recalcula al aplicar filtros. */
+  statusOptions: { value: string; label: string }[] = [];
 
   // Approve modal
   showApproveModal = signal(false);
@@ -208,7 +215,8 @@ export class RendicionesAdminComponent implements OnInit {
     return this.expandedApproveLineIds().has(index);
   }
 
-  applyFilters(): void {
+  /** Construye la lista unificada (sin filtrar) a partir de reportes y anticipos huérfanos. */
+  private buildItems(): UnifiedRendicionItem[] {
     const reportItems: UnifiedRendicionItem[] = this.allReports.map(r => {
       const uid = typeof r.userId === 'object' ? r.userId?._id : r.userId;
       const pid = typeof r.projectId === 'object' ? r.projectId?._id : r.projectId;
@@ -265,7 +273,18 @@ export class RendicionesAdminComponent implements OnInit {
       };
     });
 
-    const items = [...reportItems, ...advanceItems];
+    return [...reportItems, ...advanceItems];
+  }
+
+  applyFilters(): void {
+    const items = this.buildItems();
+
+    // Estados presentes en el conjunto sin filtrar → lista estable para el <select> de Estado.
+    const statusMap = new Map<string, string>();
+    for (const i of items) if (!statusMap.has(i.status)) statusMap.set(i.status, i.statusLabel);
+    this.statusOptions = [...statusMap.entries()]
+      .map(([value, label]) => ({ value, label }))
+      .sort((a, b) => a.label.localeCompare(b.label));
 
     let result = items;
 
@@ -274,6 +293,9 @@ export class RendicionesAdminComponent implements OnInit {
     }
     if (this.filterProjectId) {
       result = result.filter(i => i.projectId === this.filterProjectId);
+    }
+    if (this.filterStatus) {
+      result = result.filter(i => i.status === this.filterStatus);
     }
     if (this.filterDateFrom) {
       const from = new Date(this.filterDateFrom).getTime();
@@ -285,21 +307,31 @@ export class RendicionesAdminComponent implements OnInit {
       result = result.filter(i => new Date(i.createdAt).getTime() <= to.getTime());
     }
 
-    this.filteredItems = result.sort(
-      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-    );
+    this.filteredItems = this.sortItems(result);
+  }
+
+  /** Ordena según `sortBy` (fecha o monto, ascendente/descendente). */
+  private sortItems(items: UnifiedRendicionItem[]): UnifiedRendicionItem[] {
+    const arr = [...items];
+    switch (this.sortBy) {
+      case 'amount_desc': return arr.sort((a, b) => b.amount - a.amount);
+      case 'amount_asc':  return arr.sort((a, b) => a.amount - b.amount);
+      case 'date_asc':    return arr.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+      default:            return arr.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+    }
   }
 
   clearFilters(): void {
     this.filterUserId = '';
     this.filterProjectId = '';
+    this.filterStatus = '';
     this.filterDateFrom = '';
     this.filterDateTo = '';
     this.applyFilters();
   }
 
   get hasActiveFilters(): boolean {
-    return !!(this.filterUserId || this.filterProjectId || this.filterDateFrom || this.filterDateTo);
+    return !!(this.filterUserId || this.filterProjectId || this.filterStatus || this.filterDateFrom || this.filterDateTo);
   }
 
   // Detalle de solicitud de viático (popup): coordinador/contabilidad ven lo solicitado

--- a/src/app/modules/rendiciones-caja-chica/rendiciones-caja-chica.component.html
+++ b/src/app/modules/rendiciones-caja-chica/rendiciones-caja-chica.component.html
@@ -19,7 +19,7 @@
 
   <!-- Filtros -->
   <div class="bg-white rounded-2xl border border-gray-200 shadow-sm p-4 mb-5">
-    <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+    <div class="grid grid-cols-1 sm:grid-cols-4 gap-3">
       <div class="sm:col-span-2">
         <label class="block text-xs font-medium text-gray-500 mb-1">Buscar</label>
         <div class="relative">
@@ -39,6 +39,16 @@
           <option value="">Todos</option>
           <option value="draft">Borrador</option>
           <option value="finalized">Finalizado</option>
+        </select>
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-gray-500 mb-1">Ordenar por</label>
+        <select [ngModel]="sortBy()" (ngModelChange)="sortBy.set($event)"
+          class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 bg-white">
+          <option value="date_desc">Fecha (reciente primero)</option>
+          <option value="date_asc">Fecha (antigua primero)</option>
+          <option value="total_desc">Total (mayor a menor)</option>
+          <option value="total_asc">Total (menor a mayor)</option>
         </select>
       </div>
     </div>

--- a/src/app/modules/rendiciones-caja-chica/rendiciones-caja-chica.component.ts
+++ b/src/app/modules/rendiciones-caja-chica/rendiciones-caja-chica.component.ts
@@ -25,6 +25,7 @@ export class RendicionesCajaChicaComponent implements OnInit {
 
   searchFilter = signal('');
   filterStatus = signal('');
+  sortBy = signal<'date_desc' | 'date_asc' | 'total_desc' | 'total_asc'>('date_desc');
 
   // ─── Filas expandibles (detalle inline para no cortar columnas) ─────────────
   expandedRows = signal<Set<string>>(new Set<string>());
@@ -39,11 +40,18 @@ export class RendicionesCajaChicaComponent implements OnInit {
   filteredReports = computed(() => {
     const s = this.searchFilter().toLowerCase().trim();
     const status = this.filterStatus();
-    return this.reports().filter(r => {
+    const rows = this.reports().filter(r => {
       const matchSearch = !s || r.title.toLowerCase().includes(s) || (r.codigo ?? '').toLowerCase().includes(s);
       const matchStatus = !status || r.status === status;
       return matchSearch && matchStatus;
     });
+    const arr = [...rows];
+    switch (this.sortBy()) {
+      case 'total_desc': return arr.sort((a, b) => (Number(b.totalAmount) || 0) - (Number(a.totalAmount) || 0));
+      case 'total_asc':  return arr.sort((a, b) => (Number(a.totalAmount) || 0) - (Number(b.totalAmount) || 0));
+      case 'date_asc':   return arr.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+      default:           return arr.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+    }
   });
 
   ngOnInit(): void {

--- a/src/app/modules/rendiciones-directas/rendiciones-directas.component.html
+++ b/src/app/modules/rendiciones-directas/rendiciones-directas.component.html
@@ -64,11 +64,35 @@
       </div>
       <div>
         <label class="block text-xs font-medium text-gray-500 mb-1">Colaborador</label>
-        <select [(ngModel)]="filterUserId" class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 bg-white">
+        <app-worker-select
+          [(ngModel)]="filterUserId"
+          [workers]="users()"
+          [allowEmpty]="true"
+          emptyLabel="Todos"
+          placeholder="Todos"
+          triggerClass="!rounded-lg !py-2"
+        />
+      </div>
+      @if (activeTab() === 'rendiciones') {
+      <div>
+        <label class="block text-xs font-medium text-gray-500 mb-1">Estado</label>
+        <select [ngModel]="reportStatusFilter()" (ngModelChange)="reportStatusFilter.set($event)"
+          class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 bg-white">
           <option value="">Todos</option>
-          @for (u of users(); track u._id) { <option [value]="u._id">{{ u.name || u.email }}</option> }
+          @for (s of reportStatusOptions(); track s) { <option [value]="s">{{ s }}</option> }
         </select>
       </div>
+      <div>
+        <label class="block text-xs font-medium text-gray-500 mb-1">Ordenar por</label>
+        <select [ngModel]="reportSortBy()" (ngModelChange)="reportSortBy.set($event)"
+          class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 bg-white">
+          <option value="date_desc">Fecha (reciente primero)</option>
+          <option value="date_asc">Fecha (antigua primero)</option>
+          <option value="gastado_desc">Gastado (mayor a menor)</option>
+          <option value="gastado_asc">Gastado (menor a mayor)</option>
+        </select>
+      </div>
+      }
       @if (activeTab() === 'gastos') {
       <div>
         <label class="block text-xs font-medium text-gray-500 mb-1">Tipo</label>
@@ -83,10 +107,14 @@
       </div>
       <div>
         <label class="block text-xs font-medium text-gray-500 mb-1">Centro de costo</label>
-        <select [(ngModel)]="filterProjectId" class="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 bg-white">
-          <option value="">Todos</option>
-          @for (p of projects(); track p._id) { <option [value]="p._id">{{ p.code ? p.code + ' — ' : '' }}{{ p.name }}</option> }
-        </select>
+        <app-project-select
+          [(ngModel)]="filterProjectId"
+          [projects]="projects()"
+          [allowEmpty]="true"
+          emptyLabel="Todos"
+          placeholder="Todos"
+          triggerClass="!rounded-lg !py-2"
+        />
       </div>
       <div>
         <label class="block text-xs font-medium text-gray-500 mb-1">Categoria</label>
@@ -424,13 +452,13 @@
     <div class="px-4 py-3 border-b border-gray-100">
       <p class="text-sm text-gray-500">
         @if (loadingReports()) { Cargando... }
-        @else { <span class="font-semibold text-gray-800">{{ reports().length }}</span> rendición(es) · Total gastado: <span class="font-semibold">S/ {{ reportsTotalGastado | number:'1.2-2' }}</span> }
+        @else { <span class="font-semibold text-gray-800">{{ displayedReports().length }}</span> rendición(es) · Total gastado: <span class="font-semibold">S/ {{ reportsTotalGastado | number:'1.2-2' }}</span> }
       </p>
     </div>
 
     @if (loadingReports()) {
       <div class="flex items-center justify-center py-16"><span class="w-8 h-8 border-4 border-primary/20 border-t-primary rounded-full animate-spin"></span></div>
-    } @else if (reports().length === 0) {
+    } @else if (displayedReports().length === 0) {
       <div class="flex flex-col items-center justify-center py-16 text-gray-400">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-12 h-12 mb-3 opacity-40"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" /></svg>
         <p class="text-sm font-medium">Sin rendiciones directas. Ajusta los filtros.</p>
@@ -449,7 +477,7 @@
             </tr>
           </thead>
           <tbody class="divide-y divide-gray-100 bg-white">
-            @for (r of reports(); track r._id) {
+            @for (r of displayedReports(); track r._id) {
             <tr class="hover:bg-gray-50 transition-colors cursor-pointer" [class.bg-gray-50]="isExpanded(r._id)" (click)="viewReport(r)">
               <!-- Expandir -->
               <td class="px-2 py-2.5">
@@ -516,7 +544,7 @@
 
       <!-- Mobile: tarjetas (rendiciones) -->
       <div class="sm:hidden flex flex-col gap-3 p-3">
-        @for (r of reports(); track r._id) {
+        @for (r of displayedReports(); track r._id) {
         <div class="border border-gray-200 rounded-xl p-3.5 active:bg-gray-50 transition-colors" (click)="viewReport(r)">
           <div class="flex items-center justify-between gap-2 mb-2">
             <span class="font-mono text-xs font-semibold text-gray-800">{{ r.codigo || '—' }}</span>

--- a/src/app/modules/rendiciones-directas/rendiciones-directas.component.ts
+++ b/src/app/modules/rendiciones-directas/rendiciones-directas.component.ts
@@ -1,6 +1,8 @@
-import { Component, OnInit, inject, signal } from '@angular/core';
+import { Component, OnInit, inject, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { WorkerSelectComponent } from '../../design-system/worker-select/worker-select.component';
+import { ProjectSelectComponent } from '../../design-system/project-select/project-select.component';
 import { Router } from '@angular/router';
 import { ExpenseReportsService } from '../../services/expense-reports.service';
 import { UserStateService } from '../../services/user-state.service';
@@ -25,7 +27,7 @@ import {
 @Component({
   selector: 'app-rendiciones-directas',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, WorkerSelectComponent, ProjectSelectComponent],
   templateUrl: './rendiciones-directas.component.html',
 })
 export class RendicionesDirectasComponent implements OnInit {
@@ -50,6 +52,42 @@ export class RendicionesDirectasComponent implements OnInit {
   // Estado — pestaña Rendiciones directas (por reporte)
   reports = signal<any[]>([]);
   loadingReports = signal(false);
+
+  // Filtro de estado y orden para la pestaña Rendiciones directas (client-side:
+  // la lista de reportes se carga completa, sin paginación, así que se puede
+  // filtrar/ordenar sobre el conjunto ya cargado sin perder resultados).
+  reportStatusFilter = signal('');
+  reportSortBy = signal<'date_desc' | 'date_asc' | 'gastado_desc' | 'gastado_asc'>('date_desc');
+
+  /**
+   * Etiquetas de estado presentes en los reportes cargados (para el <select> de Estado).
+   * Se deduplica por la etiqueta visible —no por el `status` crudo— porque varios estados
+   * distintos se muestran con la misma etiqueta (p. ej. `status: 'closed'`, o cualquier
+   * estado con `effectivelyClosed: true`, se ven todos como "Cerrada"). Agruparlos evita
+   * opciones repetidas y hace que el filtro coincida con lo que el usuario ve en la columna.
+   */
+  reportStatusOptions = computed<string[]>(() => {
+    const set = new Set<string>();
+    for (const r of this.reports()) {
+      const label = this.reportStatusLabel(r);
+      if (label && label !== '—') set.add(label);
+    }
+    return [...set].sort((a, b) => a.localeCompare(b));
+  });
+
+  /** Reportes tras aplicar filtro de estado y orden (lo que se muestra en la tabla). */
+  displayedReports = computed<any[]>(() => {
+    const status = this.reportStatusFilter();
+    let rows = this.reports();
+    if (status) rows = rows.filter(r => this.reportStatusLabel(r) === status);
+    const arr = [...rows];
+    switch (this.reportSortBy()) {
+      case 'gastado_desc': return arr.sort((a, b) => (Number(b?.totalGastado) || 0) - (Number(a?.totalGastado) || 0));
+      case 'gastado_asc':  return arr.sort((a, b) => (Number(a?.totalGastado) || 0) - (Number(b?.totalGastado) || 0));
+      case 'date_asc':     return arr.sort((a, b) => new Date(a?.createdAt).getTime() - new Date(b?.createdAt).getTime());
+      default:             return arr.sort((a, b) => new Date(b?.createdAt).getTime() - new Date(a?.createdAt).getTime());
+    }
+  });
 
   // Filtros
   filterDateFrom = '';
@@ -172,6 +210,7 @@ export class RendicionesDirectasComponent implements OnInit {
     this.filterDateFrom = ''; this.filterDateTo = ''; this.filterProjectId = '';
     this.filterCategoryId = ''; this.filterDocNumber = ''; this.filterTipo = '';
     this.filterUserId = '';
+    this.reportStatusFilter.set(''); this.reportSortBy.set('date_desc');
     this.page = 1; this.loadReports(); this.loadData();
   }
 
@@ -212,7 +251,7 @@ export class RendicionesDirectasComponent implements OnInit {
   }
 
   get reportsTotalGastado(): number {
-    return this.reports().reduce((sum, r) => sum + (Number(r?.totalGastado) || 0), 0);
+    return this.displayedReports().reduce((sum, r) => sum + (Number(r?.totalGastado) || 0), 0);
   }
 
   goToPage(p: number): void { if (p < 1 || p > this.pages()) return; this.page = p; this.loadData(); }


### PR DESCRIPTION
- Colaborador y Centro de costo ahora tipeables/buscables (app-worker-select y app-project-select) en Rendiciones y Directas.
- Rendiciones: nuevo filtro de Estado (derivado de los datos) y selector de orden (monto/fecha, asc/desc).
- Directas (sub-tab Rendiciones directas): filtro de Estado + orden client-side; el Estado se agrupa por etiqueta visible para no repetir "Cerrada" (effectivelyClosed).
- Caja Chica: selector de orden (total/fecha).
- worker-select: opcion "Todos" (allowEmpty/emptyLabel + clear).
- worker-select/project-select: panel del desplegable con ancho minimo (320px), recortado al viewport y realineado si se desborda.