### PR TITLE
fix(viaticos): mostrar "Cerrada" cuando el saldo ya se trasladó a otr…

### DIFF
--- a/src/app/modules/admin-users/rendiciones-admin/rendiciones-admin.component.ts
+++ b/src/app/modules/admin-users/rendiciones-admin/rendiciones-admin.component.ts
@@ -215,6 +215,18 @@ export class RendicionesAdminComponent implements OnInit {
     return this.expandedApproveLineIds().has(index);
   }
 
+  /**
+   * Una rendición/viático se considera cerrada (a efectos del label) cuando su
+   * saldo pendiente ya fue resuelto: trasladado a otra solicitud/anticipo o
+   * devuelto con comprobante. Mismo criterio que mis-rendiciones y el detalle.
+   */
+  private isReportEffectivelyClosed(r: IExpenseReport): boolean {
+    return r.status === 'closed'
+      || !!(r as any).pendingBalanceUsedInRendicionId
+      || !!(r as any).pendingBalanceUsedInAdvanceId
+      || !!(r as any).returnVoucher;
+  }
+
   /** Construye la lista unificada (sin filtrar) a partir de reportes y anticipos huérfanos. */
   private buildItems(): UnifiedRendicionItem[] {
     const reportItems: UnifiedRendicionItem[] = this.allReports.map(r => {
@@ -233,8 +245,8 @@ export class RendicionesAdminComponent implements OnInit {
         projectId: pid ?? '',
         amount: r.viaticoAmount ?? r.budget ?? 0,
         status: r.status,
-        statusLabel: REPORT_STATUS_LABELS[r.status] ?? r.status,
-        statusColor: REPORT_STATUS_COLORS[r.status] ?? 'bg-gray-100 text-gray-700',
+        statusLabel: this.isReportEffectivelyClosed(r) ? 'Cerrada' : (REPORT_STATUS_LABELS[r.status] ?? r.status),
+        statusColor: this.isReportEffectivelyClosed(r) ? 'bg-gray-100 text-gray-500' : (REPORT_STATUS_COLORS[r.status] ?? 'bg-gray-100 text-gray-700'),
         createdAt: r.createdAt,
         canDeleteItem: this.canDeleteReport(r),
         canApproveL1: isViatico && r.status === 'pending_l1' && this.userCanApproveL1,

--- a/src/app/modules/mis-rendiciones/mis-rendiciones.component.ts
+++ b/src/app/modules/mis-rendiciones/mis-rendiciones.component.ts
@@ -404,11 +404,15 @@ export class MisRendicionesComponent implements OnInit {
   // ─── Viático unificado helpers ─────────────────────────────────────────────
 
   viaticoPhaseLabel(report: IExpenseReport): string {
+    // Saldo ya resuelto (trasladado a otra solicitud o devuelto) => Cerrada,
+    // mismo criterio que las rendiciones directas y el detalle.
+    if (this.isReportEffectivelyClosed(report)) return 'Cerrada';
     return this.VIATICO_REPORT_STATUS_LABELS[report.status as keyof typeof VIATICO_REPORT_STATUS_LABELS]
       ?? report.status.toUpperCase();
   }
 
   viaticoPhaseColor(report: IExpenseReport): string {
+    if (this.isReportEffectivelyClosed(report)) return 'bg-gray-100 text-gray-500';
     return this.VIATICO_REPORT_STATUS_COLORS[report.status as keyof typeof VIATICO_REPORT_STATUS_COLORS]
       ?? 'bg-gray-100 text-gray-600';
   }


### PR DESCRIPTION
…a solicitud

Los viáticos cuyo saldo pendiente ya fue jalado a la siguiente solicitud (pendingBalanceUsedInAdvanceId / pendingBalanceUsedInRendicionId) seguían mostrando "Aprobada" al colaborador y en contabilidad, aunque el saldo ya estaba resuelto. Las rendiciones directas ya se relabelan como "Cerrada" en ese caso; se extiende el mismo criterio (isReportEffectivelyClosed) al pipeline de labels de viáticos en mis-rendiciones y a la lista de rendiciones-admin.

Cambio solo de visualizacion: el status en BD sigue siendo 'approved'.