### PR TITLE
fix(viaticos): coordinador ve ampliaciones de viaticos en colas de ap…

### DIFF
--- a/src/app/modules/admin-users/rendiciones-admin/rendiciones-admin.component.ts
+++ b/src/app/modules/admin-users/rendiciones-admin/rendiciones-admin.component.ts
@@ -2,7 +2,8 @@ import { Component, OnInit, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router, ActivatedRoute, RouterModule } from '@angular/router';
-import { Observable, forkJoin } from 'rxjs';
+import { Observable, forkJoin, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 import { ExpenseReportsService } from '../../../services/expense-reports.service';
 import { AdminUsersService } from '../services/admin-users.service';
 import { InvoicesService } from '../../invoices/services/invoices.service';
@@ -158,10 +159,21 @@ export class RendicionesAdminComponent implements OnInit {
     forkJoin({
       reports: this.expenseReportsService.findAllByClient(clientId),
       advances: this.advanceService.findOrphaned(clientId),
+      // Ampliaciones de viáticos = advances con expenseReportId; findOrphaned las excluye
+      // (solo trae huérfanos), así que el coordinador no las veía. Las traemos por separado
+      // y añadimos SOLO las pendientes de aprobación para que se puedan ver/aprobar aquí.
+      linkedPending: this.advanceService.findForViaticosPage({}).pipe(catchError(() => of([]))),
     }).subscribe({
-      next: ({ reports, advances }) => {
+      next: ({ reports, advances, linkedPending }) => {
         this.allReports = reports.filter((r) => !r.isDirecta);
-        this.allOrphanedAdvances = advances;
+        const orphanIds = new Set(advances.map((a) => a._id));
+        const pendingAmpliaciones = (linkedPending ?? []).filter(
+          (a) =>
+            !!a.expenseReportId &&
+            ['pending_l1', 'pending_l2'].includes(a.status) &&
+            !orphanIds.has(a._id)
+        );
+        this.allOrphanedAdvances = [...advances, ...pendingAmpliaciones];
         this.applyFilters();
         this.isLoading = false;
       },

--- a/src/app/modules/inicio/inicio.component.ts
+++ b/src/app/modules/inicio/inicio.component.ts
@@ -50,7 +50,7 @@ export class InicioComponent implements OnInit {
 
   // Coordinador: datos del equipo (scope por personal lo aplica el backend)
   teamReports = signal<IExpenseReport[]>([]);
-  teamAdvances = signal<IAdvance[]>([]); // solicitudes de viáticos legacy del equipo (orphaned)
+  teamAdvances = signal<IAdvance[]>([]); // solicitudes de viáticos del equipo (huérfanas + ampliaciones con expenseReportId)
 
   // Toggles "ver más / expandir" por listado
   showAllViaticos = signal(false);       // Mi actividad: mis solicitudes de viáticos
@@ -333,7 +333,10 @@ export class InicioComponent implements OnInit {
     const userId = (this.userState.getUser() as any)?._id;
     forkJoin({
       team: this.expenseReportsService.findAllByClient(clientId).pipe(catchError(() => of([]))),
-      teamAdvances: this.advanceService.findOrphaned(clientId).pipe(catchError(() => of([]))),
+      // findForViaticosPage trae las solicitudes de viáticos del coordinador (por coordinatorId),
+      // incluidas las AMPLIACIONES (advances con expenseReportId) — que findOrphaned excluía, por lo
+      // que no aparecían en "Solicitudes por aprobar". solicitudesRows filtra a pending_l1/l2.
+      teamAdvances: this.advanceService.findForViaticosPage({}).pipe(catchError(() => of([]))),
       ownReports: this.expenseReportsService.findAllByUser(userId, clientId).pipe(catchError(() => of([]))),
       ownViaticos: this.expenseReportsService.getMyViaticos().pipe(catchError(() => of([]))),
       ownAdvances: this.advanceService.findMy().pipe(catchError(() => of([]))),
@@ -357,7 +360,7 @@ export class InicioComponent implements OnInit {
     if (!clientId) return;
     forkJoin({
       team: this.expenseReportsService.findAllByClient(clientId).pipe(catchError(() => of([]))),
-      teamAdvances: this.advanceService.findOrphaned(clientId).pipe(catchError(() => of([]))),
+      teamAdvances: this.advanceService.findForViaticosPage({}).pipe(catchError(() => of([]))),
     }).subscribe(({ team, teamAdvances }) => {
       this.teamReports.set(team);
       this.teamAdvances.set(teamAdvances);


### PR DESCRIPTION
…robacion

Las ampliaciones de viaticos (advances con expenseReportId, creadas desde una rendicion ya abierta) no aparecian en "Solicitudes por aprobar" (Inicio) ni en Rendiciones porque ambas se alimentaban de findOrphaned, que excluye los advances con expenseReportId. La solicitud llegaba como notificacion pero el coordinador no tenia donde aprobarla.

- Inicio: la cola del equipo ahora usa findForViaticosPage (por coordinatorId), que incluye las ampliaciones. solicitudesRows sigue filtrando pending_l1/l2.
- Rendiciones: se agregan las ampliaciones pendientes (pending_l1/l2) con dedup por _id.

Solo front; el endpoint viaticos/list ya devolvia estos advances. Llamada protegida con catchError -> sin cartel de error para el usuario si el endpoint fallara.