### PR TITLE
feat(solicitud-viaticos): ocultar selector de moneda y fijar solicitud en soles

### DIFF
--- a/src/app/modules/mis-rendiciones/solicitud-viaticos/solicitud-viaticos.component.html
+++ b/src/app/modules/mis-rendiciones/solicitud-viaticos/solicitud-viaticos.component.html
@@ -100,8 +100,9 @@
         </div>
         <div class="px-5 py-5 grid grid-cols-1 md:grid-cols-2 gap-5">
 
-          <!-- Moneda (primero: condiciona el resto del formulario) -->
-          <div class="md:col-span-2 flex flex-col gap-1.5">
+          <!-- Moneda (oculta): la solicitud queda fija en soles (PEN). Se mantiene el
+               control en el DOM para no romper el formulario, pero no se muestra. -->
+          <div class="hidden md:col-span-2 flex flex-col gap-1.5">
             <label class="text-sm font-medium text-gray-700">
               Moneda de la solicitud <span class="text-red-500">*</span>
             </label>

--- a/src/app/modules/mis-rendiciones/solicitud-viaticos/solicitud-viaticos.component.ts
+++ b/src/app/modules/mis-rendiciones/solicitud-viaticos/solicitud-viaticos.component.ts
@@ -413,21 +413,15 @@ export class SolicitudViaticosComponent implements OnInit {
     });
   }
 
-  /** Monedas configuradas por la empresa; si no hay config guardada, se queda con el default PEN. */
+  /**
+   * Selector de moneda oculto: la solicitud queda fija en soles (PEN). Ignoramos la
+   * moneda base y las monedas soportadas de la config de la empresa para que el
+   * formulario siempre se registre y envíe en soles.
+   */
   private loadCurrencyOptions(): void {
-    const clientId = this.resolveCompanyId();
-    if (!clientId) return;
-    this.accountingConfigService.getCurrencies(clientId).subscribe({
-      next: (config) => {
-        if (config?.monedaBase) {
-          this.monedaBase.set(config.monedaBase);
-        }
-        if (config?.supportedCurrencies?.length) {
-          this.currencyOptions.set(config.supportedCurrencies);
-        }
-      },
-      error: () => {},
-    });
+    this.monedaBase.set('PEN');
+    this.selectedMoneda.set('PEN');
+    this.form.get('moneda')?.setValue('PEN', { emitEvent: false });
   }
 
   private loadCatalogues(): void {
@@ -473,7 +467,7 @@ export class SolicitudViaticosComponent implements OnInit {
       place: adv.place ?? '',
       startDate: this.ymdFromDate(adv.startDate),
       endDate: this.ymdFromDate(adv.endDate),
-      moneda: adv.moneda || 'PEN',
+      moneda: 'PEN',
       observations: adv.observations ?? '',
     });
     if (adv.requestAccountNumber) {
@@ -517,7 +511,7 @@ export class SolicitudViaticosComponent implements OnInit {
       place: report.viaticoPlace ?? '',
       startDate: this.ymdFromDate(report.viaticoStartDate),
       endDate: this.ymdFromDate(report.viaticoEndDate),
-      moneda: report.moneda || 'PEN',
+      moneda: 'PEN',
       observations: report.viaticoObservations ?? '',
     });
     if (report.viaticoAccountNumber) {


### PR DESCRIPTION
## Resumen

Oculta (sin eliminar) el selector de moneda en el formulario de solicitud de viáticos y deja la solicitud fija en **soles (PEN)**.

## Cambios

- **HTML**: el bloque del selector de moneda se mantiene en el DOM pero con la clase `hidden`, así no se muestra y el control del formulario sigue funcionando.
- **TS**:
  - `loadCurrencyOptions()` ignora la moneda base y las monedas soportadas de la configuración de la empresa, y fija `monedaBase`, `selectedMoneda` y el control `moneda` en `PEN`.
  - La precarga de solicitudes existentes (`bootstrapFromAdvance` y `bootstrapFromViatico`) fuerza `PEN` en lugar de heredar la moneda guardada.

Con esto el formulario siempre se registra y envía con moneda `PEN`, tanto en solicitudes nuevas como en reenvíos/ediciones, y todos los importes se muestran con el símbolo `S/`.

## Verificación

- El componente compila sin errores de TypeScript relacionados con el cambio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XraP8qTVoG2tBJUHnkNd87

---
_Generated by [Claude Code](https://claude.ai/code/session_01XraP8qTVoG2tBJUHnkNd87)_