### PR TITLE
feat(DJ): flag djType en categorias + autoseleccion por perfil en Dec…

### DIFF
--- a/src/app/modules/categorias/categoria-form/categoria-form.component.html
+++ b/src/app/modules/categorias/categoria-form/categoria-form.component.html
@@ -91,6 +91,26 @@
         <p class="text-xs text-tertiary">Al superar este monto el sistema mostrará una advertencia. Dejar vacío para sin límite.</p>
       </div>
 
+      <!-- Declaración Jurada (viaje al exterior) -->
+      <div class="flex flex-col gap-1.5">
+        <label class="text-xs font-semibold text-tertiary uppercase tracking-wider">Declaración Jurada</label>
+        <p class="text-xs text-tertiary">Marca esta categoría como la categoría por defecto de un rubro de Declaración Jurada. Solo se puede marcar una opción por categoría. Usa una categoría DJ por perfil (p. ej. ALIMENTACION COM y ALIMENTACION PROY): en el gasto DJ se autoselecciona la del perfil del centro de costo. Dentro de un mismo perfil marca solo una por rubro.</p>
+        <div class="rounded-xl border border-tertiary/20 divide-y divide-tertiary/10 mt-1">
+          <label class="flex items-center gap-3 px-4 py-2.5 hover:bg-background cursor-pointer transition-colors">
+            <input type="checkbox" class="h-4 w-4 rounded border-tertiary/40 accent-primary cursor-pointer"
+              [checked]="form.djType === 'alimentacion'"
+              (change)="toggleDjType('alimentacion', $any($event.target).checked)" />
+            <span class="text-sm text-secondary">Alimentación DJ</span>
+          </label>
+          <label class="flex items-center gap-3 px-4 py-2.5 hover:bg-background cursor-pointer transition-colors">
+            <input type="checkbox" class="h-4 w-4 rounded border-tertiary/40 accent-primary cursor-pointer"
+              [checked]="form.djType === 'movilidad'"
+              (change)="toggleDjType('movilidad', $any($event.target).checked)" />
+            <span class="text-sm text-secondary">Movilidad DJ</span>
+          </label>
+        </div>
+      </div>
+
       <!-- Perfiles de Categoría -->
       <div class="flex flex-col gap-1.5">
         <label class="text-xs font-semibold text-tertiary uppercase tracking-wider">Perfiles de Categoría</label>

--- a/src/app/modules/categorias/categoria-form/categoria-form.component.ts
+++ b/src/app/modules/categorias/categoria-form/categoria-form.component.ts
@@ -9,6 +9,8 @@ import { ICategory } from '../../invoices/interfaces/category.interface';
 import { ICategoryGroup } from '../interfaces/category-group.interface';
 import { HttpErrorResponse } from '@angular/common/http';
 
+type DjType = 'alimentacion' | 'movilidad' | null;
+
 interface CategoryForm {
   name: string;
   description: string;
@@ -16,6 +18,7 @@ interface CategoryForm {
   cuentaDestino6x: string;
   observaciones: string;
   limit: number | null;
+  djType: DjType;
 }
 
 @Component({
@@ -35,7 +38,7 @@ export class CategoriaFormComponent implements OnInit {
   loading = signal(false);
   saving = signal(false);
 
-  form: CategoryForm = { name: '', description: '', cuenta: '', cuentaDestino6x: '', observaciones: '', limit: null };
+  form: CategoryForm = { name: '', description: '', cuenta: '', cuentaDestino6x: '', observaciones: '', limit: null, djType: null };
 
   perfiles: ICategoryGroup[] = [];
   selectedPerfiles = new Set<string>();
@@ -80,6 +83,14 @@ export class CategoriaFormComponent implements OnInit {
     else this.selectedPerfiles.delete(id);
   }
 
+  /**
+   * Flags de Declaración Jurada: "Alimentación DJ" y "Movilidad DJ" son mutuamente
+   * excluyentes. Marcar uno desmarca el otro; desmarcar el activo deja `null`.
+   */
+  toggleDjType(type: 'alimentacion' | 'movilidad', checked: boolean) {
+    this.form.djType = checked ? type : null;
+  }
+
   loadCategory(id: string) {
     this.loading.set(true);
     this.categoriaService.getOne(id).subscribe({
@@ -91,6 +102,7 @@ export class CategoriaFormComponent implements OnInit {
           cuentaDestino6x: cat.cuentaDestino6x ?? '',
           observaciones: cat.observaciones ?? '',
           limit: cat.limit ?? null,
+          djType: cat.djType ?? null,
         };
         this.loading.set(false);
       },
@@ -114,6 +126,8 @@ export class CategoriaFormComponent implements OnInit {
       cuentaDestino6x: this.form.cuentaDestino6x.trim() || undefined,
       observaciones: this.form.observaciones.trim() || undefined,
       limit: this.form.limit,
+      // null limpia el flag DJ en el back (PartialType + findOneAndUpdate).
+      djType: this.form.djType,
       perfilIds: Array.from(this.selectedPerfiles),
     };
     this.saving.set(true);

--- a/src/app/modules/invoices/add-invoice/add-invoice.component.html
+++ b/src/app/modules/invoices/add-invoice/add-invoice.component.html
@@ -125,6 +125,8 @@
       }
     </div>
 
+    <!-- En Declaración Jurada la categoría se autoasigna por proyecto: se oculta el selector. -->
+    @if (!isDj()) {
     <div class="flex flex-col gap-2">
       <label for="categoryId" class="text-sm font-medium text-secondary">
         Categoría <span class="text-error">*</span>
@@ -151,6 +153,7 @@
       <span class="text-sm text-error">La categoría es requerida</span>
       }
     </div>
+    }
   </div>
   }
 
@@ -873,7 +876,7 @@
           {code:'OT', label:'Otros'}
         ]; track opt.code) {
         <button type="button"
-          (click)="otrosSubTipo.set(opt.code)"
+          (click)="selectOtrosSubTipo(opt.code)"
           class="flex flex-col items-center justify-center gap-1 p-3 rounded-xl border-2 transition-all text-center"
           [class.border-primary]="otrosSubTipo() === opt.code"
           [class.bg-primary]="otrosSubTipo() === opt.code"
@@ -982,8 +985,8 @@
       </div>
       <div class="flex flex-col gap-2">
         <label class="text-sm font-medium text-secondary">Moneda</label>
-        <input type="text" formControlName="djMoneda" placeholder="US$"
-          class="w-full h-[42px] px-4 rounded-lg border border-gray-200 bg-white focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all text-sm" />
+        <input type="text" formControlName="djMoneda" placeholder="US$" readonly
+          class="w-full h-[42px] px-4 rounded-lg border border-gray-200 bg-gray-50 text-tertiary cursor-not-allowed focus:outline-none transition-all text-sm" />
       </div>
     </div>
 
@@ -994,7 +997,10 @@
         <button type="button" (click)="addDjRow('alimentacion')"
           class="text-xs font-semibold text-primary hover:underline">+ Agregar fila</button>
       </div>
-      @if (djAlimentacionRowsArray.length > 0) {
+      <!-- Categoría autoasignada por proyecto (flag "Alimentación DJ"). Respaldo manual si el perfil no la define. -->
+      @if (djAlimentacionAuto()) {
+      <p class="text-xs text-tertiary">Categoría: <span class="font-semibold text-secondary">{{ djAlimentacionAuto()?.name }}</span></p>
+      } @else if (djAlimentacionRowsArray.length > 0) {
       <div class="flex flex-col gap-2">
         <label class="text-xs font-medium text-secondary">Categoría <span class="text-error">*</span></label>
         <select formControlName="djAlimentacionCategoryId"
@@ -1040,7 +1046,10 @@
         <button type="button" (click)="addDjRow('movilidad')"
           class="text-xs font-semibold text-primary hover:underline">+ Agregar fila</button>
       </div>
-      @if (djMovilidadRowsArray.length > 0) {
+      <!-- Categoría autoasignada por proyecto (flag "Movilidad DJ"). Respaldo manual si el perfil no la define. -->
+      @if (djMovilidadAuto()) {
+      <p class="text-xs text-tertiary">Categoría: <span class="font-semibold text-secondary">{{ djMovilidadAuto()?.name }}</span></p>
+      } @else if (djMovilidadRowsArray.length > 0) {
       <div class="flex flex-col gap-2">
         <label class="text-xs font-medium text-secondary">Categoría <span class="text-error">*</span></label>
         <select formControlName="djMovilidadCategoryId"

--- a/src/app/modules/invoices/add-invoice/add-invoice.component.ts
+++ b/src/app/modules/invoices/add-invoice/add-invoice.component.ts
@@ -316,6 +316,8 @@ export default class AddInvoiceComponent implements OnInit {
       if (allowed && selected && !allowed.has(String(selected))) {
         this.form.get('categoryId')?.setValue('');
       }
+      // Reevalúa la categoría DJ autoseleccionada según el perfil del nuevo proyecto.
+      this.autoSelectDjCategories();
     });
     this.route.queryParamMap.subscribe(params => {
       this.rendicionId = params.get('rendicionId');
@@ -556,6 +558,7 @@ export default class AddInvoiceComponent implements OnInit {
     this.invoiceService.getCategories().subscribe({
       next: (categories) => {
         this.categories = categories;
+        this.autoSelectDjCategories();
       },
       error: (error) => {},
     });
@@ -565,6 +568,7 @@ export default class AddInvoiceComponent implements OnInit {
     this.categoryGroupService.getAll().subscribe({
       next: (groups) => {
         this.categoryGroups = groups ?? [];
+        this.autoSelectDjCategories();
       },
       error: () => {},
     });
@@ -574,6 +578,7 @@ export default class AddInvoiceComponent implements OnInit {
     this.invoiceService.getProjects().subscribe({
       next: (projects) => {
         this.proyects = projects;
+        this.autoSelectDjCategories();
       },
     });
   }
@@ -788,6 +793,59 @@ export default class AddInvoiceComponent implements OnInit {
   // --- Declaración Jurada: filas manuales de Alimentación / Movilidad ---
   savedDeclaracionJurada = signal<IDeclaracionJuradaResponse | null>(null);
 
+  /**
+   * Categorías DJ autoseleccionadas según el perfil del proyecto. Cuando hay una
+   * categoría marcada (`djType`) el selector manual se oculta y se muestra en modo
+   * lectura; cuando no la hay, se deja el selector como respaldo.
+   */
+  djAlimentacionAuto = signal<ICategory | null>(null);
+  djMovilidadAuto = signal<ICategory | null>(null);
+
+  /**
+   * DJ (viaje al exterior): autoselecciona las categorías de Alimentación y Movilidad
+   * a partir de las categorías del perfil del proyecto marcadas con `djType`.
+   * El match se hace con el proyecto (proyecto → perfil → categorías). Idempotente:
+   * se puede invocar tras cada carga de datos o cambio de proyecto/sub-tipo.
+   */
+  private autoSelectDjCategories(): void {
+    if (this.expenseType() !== 'otros_gastos' || this.otrosSubTipo() !== 'DJ') return;
+    const allowed = this.allowedCategoryIds();
+    // Match ESTRICTO por perfil del centro de costo (proyecto): se busca solo entre las
+    // categorías del perfil, nunca en todo el cliente. Cada perfil (COM/PROY/ADM) tiene
+    // su propia categoría DJ; sin perfil no se autoselecciona.
+    const scoped = allowed
+      ? this.categories.filter((c) => allowed.has(String(c._id)))
+      : [];
+    // Autoselecciona solo si el perfil tiene EXACTAMENTE una categoría del rubro; con 0
+    // (no configurada) o 2+ (ambigua) se deja el selector manual del perfil.
+    const uniquePick = (rubro: 'alimentacion' | 'movilidad'): ICategory | null => {
+      const matches = scoped.filter((c) => c.djType === rubro);
+      return matches.length === 1 ? matches[0] : null;
+    };
+    const alimentacion = uniquePick('alimentacion');
+    const movilidad = uniquePick('movilidad');
+
+    this.djAlimentacionAuto.set(alimentacion);
+    this.djMovilidadAuto.set(movilidad);
+
+    // Fija la categoría marcada del proyecto; si el perfil no tiene una, limpia el
+    // control para que el selector de respaldo arranque en blanco (sin arrastrar el
+    // valor de un proyecto anterior).
+    const aliValue = alimentacion?._id ?? '';
+    const aliCtrl = this.form.get('djAlimentacionCategoryId');
+    if (aliCtrl && aliCtrl.value !== aliValue) aliCtrl.setValue(aliValue);
+
+    const movValue = movilidad?._id ?? '';
+    const movCtrl = this.form.get('djMovilidadCategoryId');
+    if (movCtrl && movCtrl.value !== movValue) movCtrl.setValue(movValue);
+  }
+
+  /** Cambia el sub-tipo de "Otros gastos" y reevalúa la autoselección DJ. */
+  selectOtrosSubTipo(code: string): void {
+    this.otrosSubTipo.set(code);
+    this.autoSelectDjCategories();
+  }
+
   get djAlimentacionRowsArray(): FormArray {
     return this.form.get('djAlimentacionRows') as FormArray;
   }
@@ -848,6 +906,14 @@ export default class AddInvoiceComponent implements OnInit {
 
   isDirectaPlanilla(): boolean {
     return this.isDirectaContext() && this.expenseType() === 'planilla_movilidad';
+  }
+
+  /**
+   * Declaración Jurada (otros gastos, sub-tipo DJ): la categoría no se elige a mano,
+   * se autoasigna por proyecto, por lo que el selector superior de categoría se oculta.
+   */
+  isDj(): boolean {
+    return this.expenseType() === 'otros_gastos' && this.otrosSubTipo() === 'DJ';
   }
 
   /**

--- a/src/app/modules/invoices/interfaces/category.interface.ts
+++ b/src/app/modules/invoices/interfaces/category.interface.ts
@@ -9,6 +9,8 @@ export interface ICategory {
   observaciones?: string;
   isActive?: boolean;
   limit?: number | null;
+  /** Rubro DJ (viaje al exterior) al que se autoasigna la categoría. */
+  djType?: 'alimentacion' | 'movilidad' | null;
   createdAt?: Date;
   updatedAt?: Date;
   companyId?: string;

--- a/src/app/services/categoria.service.ts
+++ b/src/app/services/categoria.service.ts
@@ -45,8 +45,10 @@ export class CategoriaService {
     name: string;
     description?: string;
     cuenta?: string;
+    cuentaDestino6x?: string;
     observaciones?: string;
     limit?: number | null;
+    djType?: 'alimentacion' | 'movilidad' | null;
     perfilIds?: string[];
   }): Observable<ICategory> {
     return this.http.post<ICategory>(this.baseUrl, {
@@ -59,9 +61,11 @@ export class CategoriaService {
     name?: string;
     description?: string;
     cuenta?: string;
+    cuentaDestino6x?: string;
     observaciones?: string;
     isActive?: boolean;
     limit?: number | null;
+    djType?: 'alimentacion' | 'movilidad' | null;
     perfilIds?: string[];
   }): Observable<ICategory> {
     return this.http.patch<ICategory>(`${this.baseUrl}/${id}/${this.companyId}`, dto);


### PR DESCRIPTION
…laracion Jurada

- Editor de categorias: dos checks mutuamente excluyentes (Alimentacion DJ / Movilidad DJ).
- Gasto DJ (viaje al exterior): autoselecciona la categoria de cada rubro segun el perfil del centro de costo (match estricto por perfil; solo si el perfil tiene exactamente una categoria del rubro). Se ocultan los selectores de categoria (superior e internos).
- Moneda del DJ fija en US$ (readonly).